### PR TITLE
feat: PaymentOrder 와 PaymentEvent 연관관계 추가

### DIFF
--- a/src/main/java/com/ordertogether/team14_be/payment/domain/PaymentOrder.java
+++ b/src/main/java/com/ordertogether/team14_be/payment/domain/PaymentOrder.java
@@ -27,6 +27,9 @@ public class PaymentOrder extends BaseEntity {
   private Long sellerId; // 판매자 식별자
 
   @ManyToOne(fetch = FetchType.LAZY)
+  private PaymentEvent paymentEvent;
+
+  @ManyToOne(fetch = FetchType.LAZY)
   private Product productId;
 
   @Column(nullable = false)


### PR DESCRIPTION
- [x] #3

📌 관련 이슈
---
Payment Order와 Payment Event 간의 참조가 불가능

✨ PR 내용
---
Payment Order와 Payment Event 간의 연관관계를 추가
