### PR TITLE
14조 코드리뷰 5회차

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     implementation "io.jsonwebtoken:jjwt-api:${jjwt_version}"
     implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:${swagger_version}"
     implementation 'org.mapstruct:mapstruct:1.6.2'
+    implementation 'ch.hsr:geohash:1.4.0'
 
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.2'
 

--- a/src/main/java/com/ordertogether/team14_be/auth/JwtUtil.java
+++ b/src/main/java/com/ordertogether/team14_be/auth/JwtUtil.java
@@ -11,6 +11,7 @@ import javax.crypto.SecretKey;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+@Component
 public class JwtUtil {
 	private final SecretKey key;
 	private final int expireTime;

--- a/src/main/java/com/ordertogether/team14_be/auth/application/service/AuthService.java
+++ b/src/main/java/com/ordertogether/team14_be/auth/application/service/AuthService.java
@@ -1,56 +1,29 @@
 package com.ordertogether.team14_be.auth.application.service;
 
 import com.ordertogether.team14_be.auth.JwtUtil;
-import com.ordertogether.team14_be.auth.application.dto.KakaoUserInfo;
-import com.ordertogether.team14_be.auth.presentation.KakaoClient;
-import com.ordertogether.team14_be.common.web.response.ApiResponse;
 import com.ordertogether.team14_be.member.application.service.MemberService;
 import com.ordertogether.team14_be.member.persistence.entity.Member;
-import java.net.URI;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
-import java.util.Optional;
-import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
-@RequiredArgsConstructor
 @Service
 public class AuthService {
-
-	private final KakaoClient kakaoClient;
 	private final MemberService memberService;
 	private final JwtUtil jwtUtil;
 
-	@Value(("${FRONT_PAGE_SIGNUP}"))
-	String redirectPage;
-
-	public ResponseEntity<ApiResponse<String>> kakaoLogin(String authorizationCode) {
-		String kakaoToken = kakaoClient.getAccessToken(authorizationCode); // 인가코드로부터 카카오토큰 발급
-		KakaoUserInfo kakaoUserInfo = kakaoClient.getUserInfo((kakaoToken));
-		String userKakaoEmail = kakaoUserInfo.kakaoAccount().email(); // 와 사용자 카카오 이메일이야
-
-		Optional<Member> existMember = memberService.findMemberByEmail(userKakaoEmail);
-		if (existMember.isPresent()) {
-			String serviceToken =
-					jwtUtil.generateToken(memberService.getMemberId(userKakaoEmail)); // 서비스 토큰 줘야징
-			return ResponseEntity.ok((ApiResponse.with(HttpStatus.OK, "로그인 성공", serviceToken)));
-		} else {
-			return ResponseEntity.status(HttpStatus.FOUND)
-					.location(
-							URI.create(redirectPage + URLEncoder.encode(userKakaoEmail, StandardCharsets.UTF_8)))
-					.build();
-		}
+	public AuthService(MemberService memberService, JwtUtil jwtUtil) {
+		this.memberService = memberService;
+		this.jwtUtil = jwtUtil;
 	}
 
-	public ResponseEntity<ApiResponse<String>> register(
-			String email, String deliveryName, String phoneNumber) {
+	public String register(String email, String deliveryName, String phoneNumber) {
 		Member member = new Member(email, deliveryName, phoneNumber);
 		memberService.registerMember(member);
 		Long memberId = memberService.getMemberId(email);
 		String serviceToken = jwtUtil.generateToken(memberId);
-		return ResponseEntity.ok((ApiResponse.with(HttpStatus.OK, "회원가입 및 로그인 성공", serviceToken)));
+		return serviceToken;
+	}
+
+	public String getServiceToken(String email) {
+		return jwtUtil.generateToken(memberService.getMemberId(email));
 	}
 }

--- a/src/main/java/com/ordertogether/team14_be/auth/application/service/KakaoAuthService.java
+++ b/src/main/java/com/ordertogether/team14_be/auth/application/service/KakaoAuthService.java
@@ -1,0 +1,19 @@
+package com.ordertogether.team14_be.auth.application.service;
+
+import com.ordertogether.team14_be.auth.application.dto.KakaoUserInfo;
+import com.ordertogether.team14_be.auth.presentation.KakaoClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class KakaoAuthService {
+	private final KakaoClient kakaoClient;
+
+	public String getKakaoUserEmail(String authorizationCode) {
+		String kakaoToken = kakaoClient.getAccessToken(authorizationCode);
+		KakaoUserInfo kakaoUserInfo = kakaoClient.getUserInfo((kakaoToken));
+		String userKakaoEmail = kakaoUserInfo.kakaoAccount().email();
+		return userKakaoEmail;
+	}
+}

--- a/src/main/java/com/ordertogether/team14_be/auth/presentation/AuthController.java
+++ b/src/main/java/com/ordertogether/team14_be/auth/presentation/AuthController.java
@@ -1,9 +1,17 @@
 package com.ordertogether.team14_be.auth.presentation;
 
 import com.ordertogether.team14_be.auth.application.service.AuthService;
+import com.ordertogether.team14_be.auth.application.service.KakaoAuthService;
 import com.ordertogether.team14_be.common.web.response.ApiResponse;
 import com.ordertogether.team14_be.member.application.dto.MemberInfoRequest;
-import lombok.RequiredArgsConstructor;
+import com.ordertogether.team14_be.member.application.service.MemberService;
+import com.ordertogether.team14_be.member.persistence.entity.Member;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -13,16 +21,49 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/v1/auth")
 public class AuthController {
 
 	private final AuthService authService;
+	private final KakaoAuthService kakaoAuthService;
+	private final String redirectPage;
+	private final MemberService memberService;
+
+	public AuthController(
+			AuthService authService,
+			KakaoAuthService kakaoAuthService,
+			MemberService memberService,
+			@Value("${FRONT_PAGE_SIGNUP}") String redirectPage) {
+		this.authService = authService;
+		this.kakaoAuthService = kakaoAuthService;
+		this.memberService = memberService;
+		this.redirectPage = redirectPage;
+	}
 
 	@GetMapping("/login")
 	public ResponseEntity<ApiResponse<String>> getToken(@RequestHeader String authorizationCode) {
-		return authService.kakaoLogin(authorizationCode);
+		String userKakaoEmail = kakaoAuthService.getKakaoUserEmail(authorizationCode);
+		Optional<Member> existMember = memberService.findMemberByEmail(userKakaoEmail);
+		if (existMember.isPresent()) {
+			return ResponseEntity.ok(
+					ApiResponse.with(HttpStatus.OK, "로그인 성공", authService.getServiceToken(userKakaoEmail)));
+
+		} else {
+			return ResponseEntity.status(HttpStatus.FOUND)
+					.location(
+							URI.create(redirectPage + URLEncoder.encode(userKakaoEmail, StandardCharsets.UTF_8)))
+					.build();
+		}
+	}
+
+	@PostMapping("/signup")
+	public ResponseEntity<ApiResponse<String>> signUpMember(
+			@RequestParam String email, @RequestBody MemberInfoRequest memberInfoRequest) {
+		String serviceToken =
+				authService.register(
+						email, memberInfoRequest.deliveryName(), memberInfoRequest.phoneNumber());
+		return ResponseEntity.ok(ApiResponse.with(HttpStatus.OK, "로그인 성공", serviceToken));
 	}
 
 	@PostMapping("/signup")

--- a/src/main/java/com/ordertogether/team14_be/common/web/response/ApiResponse.java
+++ b/src/main/java/com/ordertogether/team14_be/common/web/response/ApiResponse.java
@@ -10,11 +10,15 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ApiResponse<T> {
 
-	private Integer status;
-	private String message;
-	private T data;
+	private final Integer status;
+	private final String message;
+	private final T data;
 
 	public static <T> ApiResponse<T> with(HttpStatus httpStatus, String message, @Nullable T data) {
 		return new ApiResponse<>(httpStatus.value(), message, data);
+	}
+
+	public static <T> ApiResponse<T> with(HttpStatus httpStatus, String message) {
+		return new ApiResponse<>(httpStatus.value(), message, null);
 	}
 }

--- a/src/main/java/com/ordertogether/team14_be/config/CorsConfig.java
+++ b/src/main/java/com/ordertogether/team14_be/config/CorsConfig.java
@@ -1,0 +1,19 @@
+package com.ordertogether.team14_be.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+	@Override
+	public void addCorsMappings(CorsRegistry registry) {
+		registry
+				.addMapping("/**")
+				.allowedOrigins("*")
+				.allowedMethods("GET", "POST", "PUT", "DELETE")
+				.allowedHeaders("Authorization", "Content-Type")
+				.exposedHeaders("Custom-Header")
+				.maxAge(3600);
+	}
+}

--- a/src/main/java/com/ordertogether/team14_be/config/PersistenceConfig.java
+++ b/src/main/java/com/ordertogether/team14_be/config/PersistenceConfig.java
@@ -27,8 +27,12 @@ public class PersistenceConfig {
 
 	@Bean
 	public PaymentEventRepository paymentEventRepository(
-			SimpleJpaPaymentEventRepository simpleJpaPaymentEventRepository) {
-		return new JpaPaymentEventRepository(simpleJpaPaymentEventRepository);
+			SimpleJpaPaymentEventRepository simpleJpaPaymentEventRepository,
+			SimpleJpaPaymentOrderRepository simpleJpaPaymentOrderRepository,
+			SimpleJpaProductRepository simpleJpaProductRepository) {
+		return new JpaPaymentEventRepository(
+				simpleJpaPaymentEventRepository,
+				paymentOrderRepository(simpleJpaPaymentOrderRepository, simpleJpaProductRepository));
 	}
 
 	@Bean

--- a/src/main/java/com/ordertogether/team14_be/member/application/service/MemberService.java
+++ b/src/main/java/com/ordertogether/team14_be/member/application/service/MemberService.java
@@ -1,6 +1,5 @@
 package com.ordertogether.team14_be.member.application.service;
 
-import com.ordertogether.team14_be.auth.JwtUtil;
 import com.ordertogether.team14_be.member.application.dto.MemberInfoResponse;
 import com.ordertogether.team14_be.member.application.exception.NotFoundMember;
 import com.ordertogether.team14_be.member.persistence.MemberRepository;
@@ -17,6 +16,25 @@ public class MemberService {
 
 	private final MemberRepository memberRepository;
 	private final JwtUtil jwtUtil;
+
+	@Transactional(readOnly = true)
+	public Long getMemberId(String email) {
+		return memberRepository
+				.findByEmail(email)
+				.map(Member::getId)
+				.orElseThrow(() -> new NoSuchElementException("Member with email " + email + " not found"));
+	}
+
+	@Transactional(readOnly = true)
+	public MemberInfoResponse findMemberInfo(Long memberId) {
+		Member member = findMember(memberId);
+
+		return MemberInfoResponse.builder()
+				.deliveryName(member.getDeliveryName())
+				.phoneNumber(member.getPhoneNumber())
+				.point(member.getPoint())
+				.build();
+	}
 
 	@Transactional(readOnly = true)
 	public Long getMemberId(String email) {
@@ -65,12 +83,8 @@ public class MemberService {
 		return memberRepository.findByEmail(email);
 	}
 
+	@Transactional
 	public void registerMember(Member member) {
 		memberRepository.saveAndFlush(member);
-	}
-
-	public Long getMemberId(String email) {
-		Member member = memberRepository.findByEmail(email).get();
-		return member.getId();
 	}
 }

--- a/src/main/java/com/ordertogether/team14_be/member/persistence/entity/Member.java
+++ b/src/main/java/com/ordertogether/team14_be/member/persistence/entity/Member.java
@@ -30,6 +30,16 @@ public class Member {
 
 	protected Member() {}
 
+	public Member(
+			Long id, String email, int point, String phoneNumber, String deliveryName, String platform) {
+		this.id = id;
+		this.email = email;
+		this.point = point;
+		this.phoneNumber = phoneNumber;
+		this.deliveryName = deliveryName;
+		this.platform = platform;
+	}
+
 	public Member(String email, int point, String phoneNumber, String deliveryName, String platform) {
 		this.email = email;
 		this.point = point;
@@ -73,18 +83,8 @@ public class Member {
 		this.phoneNumber = phoneNumber;
 	}
 
-	public void modifyMemberInfo(String deliveryName, String phoneNumber) {
-		this.deliveryName = deliveryName;
-		this.phoneNumber = phoneNumber;
-	}
-
-	public void modifyMemberInfo(String deliveryName, String phoneNumber) {
-		this.deliveryName = deliveryName;
-		this.phoneNumber = phoneNumber;
-	}
-
-	public void modifyMemberInfo(String deliveryName, String phoneNumber) {
-		this.deliveryName = deliveryName;
-		this.phoneNumber = phoneNumber;
+	public Integer increasePoint(int point) {
+		this.point += point;
+		return this.point;
 	}
 }

--- a/src/main/java/com/ordertogether/team14_be/memebr/application/service/MemberService.java
+++ b/src/main/java/com/ordertogether/team14_be/memebr/application/service/MemberService.java
@@ -1,0 +1,26 @@
+package com.ordertogether.team14_be.memebr.application.service;
+
+import com.ordertogether.team14_be.memebr.persistence.MemberRepository;
+import com.ordertogether.team14_be.memebr.persistence.entity.Member;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MemberService {
+
+	private final MemberRepository memberRepository;
+
+	public MemberService(MemberRepository memberRepository) {
+		this.memberRepository = memberRepository;
+	}
+
+	public void findOrCreateMember(String email) {
+		Member member =
+				memberRepository
+						.findByEmail(email)
+						.orElseGet(
+								() -> {
+									Member newMember = Member.createMember(email);
+									return memberRepository.saveAndFlush(newMember);
+								});
+	}
+}

--- a/src/main/java/com/ordertogether/team14_be/memebr/persistence/MemberRepository.java
+++ b/src/main/java/com/ordertogether/team14_be/memebr/persistence/MemberRepository.java
@@ -1,0 +1,12 @@
+package com.ordertogether.team14_be.memebr.persistence;
+
+import com.ordertogether.team14_be.memebr.persistence.entity.Member;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+	Optional<Member> findByEmail(String email);
+}

--- a/src/main/java/com/ordertogether/team14_be/payment/domain/PaymentStatus.java
+++ b/src/main/java/com/ordertogether/team14_be/payment/domain/PaymentStatus.java
@@ -13,4 +13,12 @@ public enum PaymentStatus {
 	FAIL("결제 실패");
 
 	private final String description;
+
+	public boolean isSuccess() {
+		return this == SUCCESS;
+	}
+
+	public boolean isFail() {
+		return this == FAIL;
+	}
 }

--- a/src/main/java/com/ordertogether/team14_be/payment/persistence/jpa/entity/PaymentEventEntity.java
+++ b/src/main/java/com/ordertogether/team14_be/payment/persistence/jpa/entity/PaymentEventEntity.java
@@ -40,7 +40,6 @@ public class PaymentEventEntity extends BaseTimeEntity {
 	@Column(nullable = false)
 	private String orderName;
 
-	@Column(nullable = false)
 	private String paymentKey; // PSP 결제 식별자
 
 	@Builder.Default

--- a/src/main/java/com/ordertogether/team14_be/payment/persistence/jpa/mapper/PaymentEventMapper.java
+++ b/src/main/java/com/ordertogether/team14_be/payment/persistence/jpa/mapper/PaymentEventMapper.java
@@ -1,7 +1,9 @@
 package com.ordertogether.team14_be.payment.persistence.jpa.mapper;
 
 import com.ordertogether.team14_be.payment.domain.PaymentEvent;
+import com.ordertogether.team14_be.payment.domain.PaymentOrder;
 import com.ordertogether.team14_be.payment.persistence.jpa.entity.PaymentEventEntity;
+import java.util.List;
 import lombok.experimental.UtilityClass;
 
 @UtilityClass
@@ -18,14 +20,16 @@ public final class PaymentEventMapper {
 				.build();
 	}
 
-	public static PaymentEvent mapToDomain(PaymentEventEntity entity) {
+	public static PaymentEvent mapToDomain(
+			PaymentEventEntity paymentEventEntity, List<PaymentOrder> paymentOrders) {
 		return PaymentEvent.builder()
-				.id(entity.getId())
-				.buyerId(entity.getBuyerId())
-				.orderId(entity.getOrderId())
-				.orderName(entity.getOrderName())
-				.paymentKey(entity.getPaymentKey())
-				.paymentStatus(entity.getPaymentStatus())
+				.id(paymentEventEntity.getId())
+				.buyerId(paymentEventEntity.getBuyerId())
+				.paymentOrders(paymentOrders)
+				.orderId(paymentEventEntity.getOrderId())
+				.orderName(paymentEventEntity.getOrderName())
+				.paymentKey(paymentEventEntity.getPaymentKey())
+				.paymentStatus(paymentEventEntity.getPaymentStatus())
 				.build();
 	}
 }

--- a/src/main/java/com/ordertogether/team14_be/payment/persistence/jpa/repository/JpaPaymentEventRepository.java
+++ b/src/main/java/com/ordertogether/team14_be/payment/persistence/jpa/repository/JpaPaymentEventRepository.java
@@ -1,33 +1,69 @@
 package com.ordertogether.team14_be.payment.persistence.jpa.repository;
 
 import com.ordertogether.team14_be.payment.domain.PaymentEvent;
+import com.ordertogether.team14_be.payment.domain.PaymentOrder;
+import com.ordertogether.team14_be.payment.domain.PaymentStatus;
 import com.ordertogether.team14_be.payment.persistence.jpa.entity.PaymentEventEntity;
 import com.ordertogether.team14_be.payment.persistence.jpa.mapper.PaymentEventMapper;
 import com.ordertogether.team14_be.payment.persistence.repository.PaymentEventRepository;
+import com.ordertogether.team14_be.payment.persistence.repository.PaymentOrderRepository;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class JpaPaymentEventRepository implements PaymentEventRepository {
 
 	private final SimpleJpaPaymentEventRepository simpleJpaPaymentEventRepository;
+	private final PaymentOrderRepository paymentOrderRepository;
 
 	@Override
+	@Transactional
 	public PaymentEvent save(PaymentEvent paymentEvent) {
 		PaymentEventEntity savedEntity =
 				simpleJpaPaymentEventRepository.save(PaymentEventMapper.mapToEntity(paymentEvent));
-		return PaymentEventMapper.mapToDomain(savedEntity);
-	}
-
-	@Override
-	public Optional<PaymentEvent> findById(Long id) {
-		return simpleJpaPaymentEventRepository.findById(id).map(PaymentEventMapper::mapToDomain);
+		return PaymentEventMapper.mapToDomain(savedEntity, paymentEvent.getPaymentOrders());
 	}
 
 	@Override
 	public Optional<PaymentEvent> findByOrderId(String orderId) {
+		List<PaymentOrder> paymentOrders = paymentOrderRepository.findByOrderId(orderId);
 		return simpleJpaPaymentEventRepository
 				.findByOrderId(orderId)
-				.map(PaymentEventMapper::mapToDomain);
+				.map(paymentEvent -> PaymentEventMapper.mapToDomain(paymentEvent, paymentOrders));
+	}
+
+	@Override
+	@Transactional
+	public Integer updatePaymentStatus(
+			String paymentKey, String orderId, PaymentStatus paymentStatus) {
+		return simpleJpaPaymentEventRepository.updatePaymentStatus(paymentKey, orderId, paymentStatus);
+	}
+
+	@Override
+	@Transactional
+	public Integer updatePaymentStatusToExecuting(String orderId, String paymentKey) {
+		checkPreviousPaymentStatus(orderId);
+		simpleJpaPaymentEventRepository.updatePaymentKey(paymentKey, orderId);
+
+		return simpleJpaPaymentEventRepository.updatePaymentStatus(
+				paymentKey, orderId, PaymentStatus.EXECUTING);
+	}
+
+	private void checkPreviousPaymentStatus(String orderId) {
+		PaymentStatus previousStatus =
+				findByOrderId(orderId)
+						.orElseThrow(
+								() ->
+										new IllegalArgumentException(
+												"orderId: %s 에 해당하는 결제 정보가 없습니다.".formatted(orderId)))
+						.getPaymentStatus();
+
+		if (previousStatus.isSuccess() || previousStatus.isFail()) {
+			throw new IllegalArgumentException(
+					"이미 %s 상태인 결제 입니다.".formatted(previousStatus.getDescription()));
+		}
 	}
 }

--- a/src/main/java/com/ordertogether/team14_be/payment/persistence/jpa/repository/JpaPaymentOrderRepository.java
+++ b/src/main/java/com/ordertogether/team14_be/payment/persistence/jpa/repository/JpaPaymentOrderRepository.java
@@ -6,11 +6,15 @@ import com.ordertogether.team14_be.payment.persistence.jpa.entity.ProductEntity;
 import com.ordertogether.team14_be.payment.persistence.jpa.mapper.PaymentOrderMapper;
 import com.ordertogether.team14_be.payment.persistence.jpa.mapper.ProductMapper;
 import com.ordertogether.team14_be.payment.persistence.repository.PaymentOrderRepository;
+import java.math.BigDecimal;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class JpaPaymentOrderRepository implements PaymentOrderRepository {
 
 	private final SimpleJpaPaymentOrderRepository simpleJpaPaymentOrderRepository;
@@ -24,6 +28,7 @@ public class JpaPaymentOrderRepository implements PaymentOrderRepository {
 	 * @return 저장된 결제 주문 정보
 	 */
 	@Override
+	@Transactional
 	public PaymentOrder save(PaymentOrder paymentOrder) {
 		addMissingProductInfo(paymentOrder);
 		PaymentOrderEntity savedEntity =
@@ -40,6 +45,7 @@ public class JpaPaymentOrderRepository implements PaymentOrderRepository {
 	}
 
 	@Override
+	@Transactional
 	public List<PaymentOrder> saveAll(List<PaymentOrder> paymentOrders) {
 		List<PaymentOrderEntity> savedEntities =
 				simpleJpaPaymentOrderRepository.saveAll(
@@ -53,12 +59,27 @@ public class JpaPaymentOrderRepository implements PaymentOrderRepository {
 		return simpleJpaPaymentOrderRepository.findById(id).map(PaymentOrderMapper::mapToDomain);
 	}
 
+	@Override
+	public List<PaymentOrder> findByOrderId(String orderId) {
+		return simpleJpaPaymentOrderRepository.findByOrderId(orderId).stream()
+				.map(PaymentOrderMapper::mapToDomain)
+				.toList();
+	}
+
+	@Override
+	public BigDecimal getPaymentTotalAmount(String orderId) {
+		return simpleJpaPaymentOrderRepository
+				.getPaymentTotalAmount(orderId)
+				.orElseThrow(
+						() -> new NoSuchElementException("주문 번호: %s 에 해당하는 주문이 존재하지 않습니다.".formatted(orderId)));
+	}
+
 	private ProductEntity getProductEntity(PaymentOrder paymentOrder) {
 		return simpleJpaProductRepository
 				.findById(paymentOrder.getProductId())
 				.orElseThrow(
 						() ->
-								new IllegalArgumentException(
+								new NoSuchElementException(
 										String.format("상품 아이디 %s에 해당하는 상품이 없습니다.", paymentOrder.getProductId())));
 	}
 }

--- a/src/main/java/com/ordertogether/team14_be/payment/persistence/jpa/repository/SimpleJpaPaymentEventRepository.java
+++ b/src/main/java/com/ordertogether/team14_be/payment/persistence/jpa/repository/SimpleJpaPaymentEventRepository.java
@@ -1,12 +1,30 @@
 package com.ordertogether.team14_be.payment.persistence.jpa.repository;
 
+import com.ordertogether.team14_be.payment.domain.PaymentStatus;
 import com.ordertogether.team14_be.payment.persistence.jpa.entity.PaymentEventEntity;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface SimpleJpaPaymentEventRepository extends JpaRepository<PaymentEventEntity, Long> {
 
 	Optional<PaymentEventEntity> findByOrderId(String orderId);
+
+	@Modifying
+	@Query(
+			"UPDATE PaymentEventEntity pee"
+					+ " SET pee.paymentStatus = :afterStatus"
+					+ " WHERE pee.paymentKey = :paymentKey"
+					+ "  AND pee.orderId = :orderId")
+	Integer updatePaymentStatus(String paymentKey, String orderId, PaymentStatus afterStatus);
+
+	@Modifying
+	@Query(
+			"UPDATE PaymentEventEntity pee"
+					+ " SET pee.paymentKey = :paymentKey"
+					+ " WHERE pee.orderId = :orderId")
+	Integer updatePaymentKey(String paymentKey, String orderId);
 }

--- a/src/main/java/com/ordertogether/team14_be/payment/persistence/jpa/repository/SimpleJpaPaymentOrderRepository.java
+++ b/src/main/java/com/ordertogether/team14_be/payment/persistence/jpa/repository/SimpleJpaPaymentOrderRepository.java
@@ -1,8 +1,18 @@
 package com.ordertogether.team14_be.payment.persistence.jpa.repository;
 
 import com.ordertogether.team14_be.payment.persistence.jpa.entity.PaymentOrderEntity;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface SimpleJpaPaymentOrderRepository extends JpaRepository<PaymentOrderEntity, Long> {}
+public interface SimpleJpaPaymentOrderRepository extends JpaRepository<PaymentOrderEntity, Long> {
+
+	@Query("SELECT SUM(po.amount) FROM PaymentOrderEntity po WHERE po.orderId = :orderId")
+	Optional<BigDecimal> getPaymentTotalAmount(String orderId);
+
+	List<PaymentOrderEntity> findByOrderId(String orderId);
+}

--- a/src/main/java/com/ordertogether/team14_be/payment/persistence/repository/PaymentEventRepository.java
+++ b/src/main/java/com/ordertogether/team14_be/payment/persistence/repository/PaymentEventRepository.java
@@ -1,13 +1,25 @@
 package com.ordertogether.team14_be.payment.persistence.repository;
 
 import com.ordertogether.team14_be.payment.domain.PaymentEvent;
+import com.ordertogether.team14_be.payment.domain.PaymentStatus;
 import java.util.Optional;
 
 public interface PaymentEventRepository {
 
 	PaymentEvent save(PaymentEvent paymentEvent);
 
-	Optional<PaymentEvent> findById(Long id);
-
 	Optional<PaymentEvent> findByOrderId(String orderId);
+
+	Integer updatePaymentStatus(String paymentKey, String orderId, PaymentStatus paymentStatus);
+
+	/**
+	 * 주문 상태를 '실행 중'으로 변경합니다.<br>
+	 * - PSP 에서 전달받은 결제 식별자 paymentKey 로 paymentKey 필드를 초기화합니다.<br>
+	 * - 주문 상태를 '실행 중'으로 변경합니다.
+	 *
+	 * @param orderId 주문 번호
+	 * @param paymentKey PSP 에서 전달 받은 결제 식별자
+	 * @return 변경된 행의 수
+	 */
+	Integer updatePaymentStatusToExecuting(String orderId, String paymentKey);
 }

--- a/src/main/java/com/ordertogether/team14_be/payment/persistence/repository/PaymentOrderRepository.java
+++ b/src/main/java/com/ordertogether/team14_be/payment/persistence/repository/PaymentOrderRepository.java
@@ -1,6 +1,7 @@
 package com.ordertogether.team14_be.payment.persistence.repository;
 
 import com.ordertogether.team14_be.payment.domain.PaymentOrder;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 
@@ -11,4 +12,14 @@ public interface PaymentOrderRepository {
 	List<PaymentOrder> saveAll(List<PaymentOrder> paymentOrders);
 
 	Optional<PaymentOrder> findById(Long id);
+
+	List<PaymentOrder> findByOrderId(String orderId);
+
+	/**
+	 * 주문 번호에 해당하는 주문에 대하여 총 결제 금액을 반환한다.
+	 *
+	 * @param orderId 주문번호
+	 * @return 총 결제 금액
+	 */
+	BigDecimal getPaymentTotalAmount(String orderId);
 }

--- a/src/main/java/com/ordertogether/team14_be/payment/service/PaymentConfirmService.java
+++ b/src/main/java/com/ordertogether/team14_be/payment/service/PaymentConfirmService.java
@@ -1,0 +1,40 @@
+package com.ordertogether.team14_be.payment.service;
+
+import com.ordertogether.team14_be.payment.service.command.PaymentStatusUpdateCommand;
+import com.ordertogether.team14_be.payment.web.request.PaymentConfirmRequest;
+import com.ordertogether.team14_be.payment.web.response.PaymentConfirmationResponse;
+import com.ordertogether.team14_be.payment.web.toss.client.TossPaymentsClient;
+import java.math.BigDecimal;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+/** 결제 승인 서비스 */
+public class PaymentConfirmService {
+
+	private final TossPaymentsClient tossPaymentsClient;
+
+	private final PaymentValidationService paymentValidationService;
+	private final PaymentStatusUpdateService paymentStatusUpdateService;
+	private final PointManagementService pointManagementService;
+
+	public PaymentConfirmationResponse confirm(PaymentConfirmRequest request) {
+		// 1. 결제 상태 변경 (준비 -> 실행 중)
+		paymentStatusUpdateService.updatePaymentStatusToExecuting(
+				request.orderId(), request.paymentKey());
+		// 2. 결제 유효성 검사
+		paymentValidationService.validate(request.orderId(), BigDecimal.valueOf(request.amount()));
+		// 3. 결제 승인 요청
+		PaymentConfirmationResponse response = tossPaymentsClient.confirmPayment(request);
+		// 4. 승인 결과에 따른 결제 상태 업데이트
+		paymentStatusUpdateService.updatePaymentStatus(
+				new PaymentStatusUpdateCommand(
+						request.paymentKey(), request.orderId(), response.paymentStatus()));
+		// 5. 포인트 충전
+		pointManagementService.increasePoint(request.orderId());
+		return response;
+	}
+}

--- a/src/main/java/com/ordertogether/team14_be/payment/service/PaymentPreparationService.java
+++ b/src/main/java/com/ordertogether/team14_be/payment/service/PaymentPreparationService.java
@@ -50,15 +50,16 @@ public class PaymentPreparationService {
 	 */
 	private void validateDuplicatePayment(PaymentPrepareRequest request) {
 		String idempotentKey = IdempotentKeyGenerator.generate(request.getIdempotencySeed());
+
 		paymentEventRepository
 				.findByOrderId(idempotentKey)
 				.ifPresent(
-						paymentEvent -> {
+						duplicatedPaymentEvent -> {
 							throw new IllegalArgumentException(
 									"Seed: %s 를 통해 생성된 결제는 이미 %s 상태인 주문입니다."
 											.formatted(
 													request.getIdempotencySeed(),
-													paymentEvent.getPaymentStatus().getDescription()));
+													duplicatedPaymentEvent.getPaymentStatus().getDescription()));
 						});
 	}
 
@@ -84,7 +85,6 @@ public class PaymentPreparationService {
 						products.stream().map(product -> createPaymentOrder(product, idempotencySeed)).toList())
 				.orderId(IdempotentKeyGenerator.generate(idempotencySeed))
 				.orderName(createOrderName(products))
-				.paymentKey(IdempotentKeyGenerator.generate(idempotencySeed))
 				.build();
 	}
 

--- a/src/main/java/com/ordertogether/team14_be/payment/service/PaymentStatusUpdateService.java
+++ b/src/main/java/com/ordertogether/team14_be/payment/service/PaymentStatusUpdateService.java
@@ -1,0 +1,25 @@
+package com.ordertogether.team14_be.payment.service;
+
+import com.ordertogether.team14_be.payment.persistence.repository.PaymentEventRepository;
+import com.ordertogether.team14_be.payment.service.command.PaymentStatusUpdateCommand;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentStatusUpdateService {
+
+	private final PaymentEventRepository paymentEventRepository;
+
+	@Transactional
+	public Integer updatePaymentStatusToExecuting(String orderId, String paymentKey) {
+		return paymentEventRepository.updatePaymentStatusToExecuting(orderId, paymentKey);
+	}
+
+	@Transactional
+	public Integer updatePaymentStatus(PaymentStatusUpdateCommand command) {
+		return paymentEventRepository.updatePaymentStatus(
+				command.paymentKey(), command.orderId(), command.paymentStatus());
+	}
+}

--- a/src/main/java/com/ordertogether/team14_be/payment/service/PaymentValidationService.java
+++ b/src/main/java/com/ordertogether/team14_be/payment/service/PaymentValidationService.java
@@ -1,0 +1,39 @@
+package com.ordertogether.team14_be.payment.service;
+
+import com.ordertogether.team14_be.payment.persistence.repository.PaymentOrderRepository;
+import java.math.BigDecimal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+/** 결제 유효성 검사 */
+public class PaymentValidationService {
+
+	private final PaymentOrderRepository paymentOrderRepository;
+
+	/**
+	 * 요청된 결제 금액과 실제 결제 금액이 일치하는 지 검증합니다.
+	 *
+	 * @param orderId 주문 번호
+	 * @param requestedAmount 요청한 결제 금액
+	 * @return 결제 금액이 일치하면 true, 그렇지 않으면 {@link IllegalArgumentException} 발생
+	 */
+	public boolean validate(String orderId, BigDecimal requestedAmount) {
+		BigDecimal expectedAmount = paymentOrderRepository.getPaymentTotalAmount(orderId);
+
+		if (isAmountMismatch(requestedAmount, expectedAmount)) {
+			throw new IllegalArgumentException(
+					"주문 번호: %s 의 결제 요청 금액 %s 원은 예상 결제 금액 %s 원과 다릅니다."
+							.formatted(orderId, requestedAmount, expectedAmount));
+		}
+
+		return true;
+	}
+
+	private boolean isAmountMismatch(BigDecimal requestedAmount, BigDecimal expectedAmount) {
+		return requestedAmount.compareTo(expectedAmount) != 0;
+	}
+}

--- a/src/main/java/com/ordertogether/team14_be/payment/service/PointManagementService.java
+++ b/src/main/java/com/ordertogether/team14_be/payment/service/PointManagementService.java
@@ -1,0 +1,31 @@
+package com.ordertogether.team14_be.payment.service;
+
+import com.ordertogether.team14_be.member.application.service.MemberService;
+import com.ordertogether.team14_be.payment.domain.PaymentEvent;
+import com.ordertogether.team14_be.payment.persistence.repository.PaymentEventRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PointManagementService {
+
+	private final PaymentEventRepository paymentEventRepository;
+	private final MemberService memberService;
+
+	@Transactional
+	public Integer increasePoint(String orderId) {
+		PaymentEvent paymentEvent =
+				paymentEventRepository
+						.findByOrderId(orderId)
+						.orElseThrow(
+								() ->
+										new IllegalArgumentException(
+												"orderId : %s 에 해당하는 PaymentEvent 가 없습니다.".formatted(orderId)));
+
+		return memberService
+				.findMember(paymentEvent.getBuyerId())
+				.increasePoint(paymentEvent.totalAmount().intValue());
+	}
+}

--- a/src/main/java/com/ordertogether/team14_be/payment/service/PointUpdateService.java
+++ b/src/main/java/com/ordertogether/team14_be/payment/service/PointUpdateService.java
@@ -1,0 +1,31 @@
+package com.ordertogether.team14_be.payment.service;
+
+import com.ordertogether.team14_be.member.application.service.MemberService;
+import com.ordertogether.team14_be.payment.domain.PaymentEvent;
+import com.ordertogether.team14_be.payment.persistence.repository.PaymentEventRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PointUpdateService {
+
+	private final PaymentEventRepository paymentEventRepository;
+	private final MemberService memberService;
+
+	@Transactional
+	public Integer increasePoint(String orderId) {
+		PaymentEvent paymentEvent =
+				paymentEventRepository
+						.findByOrderId(orderId)
+						.orElseThrow(
+								() ->
+										new IllegalArgumentException(
+												"orderId : %s 에 해당하는 PaymentEvent 가 없습니다.".formatted(orderId)));
+
+		return memberService
+				.findMember(paymentEvent.getBuyerId())
+				.increasePoint(paymentEvent.totalAmount().intValue());
+	}
+}

--- a/src/main/java/com/ordertogether/team14_be/payment/service/command/PaymentStatusUpdateCommand.java
+++ b/src/main/java/com/ordertogether/team14_be/payment/service/command/PaymentStatusUpdateCommand.java
@@ -1,0 +1,23 @@
+package com.ordertogether.team14_be.payment.service.command;
+
+import com.ordertogether.team14_be.payment.domain.PaymentStatus;
+import java.util.Objects;
+
+public record PaymentStatusUpdateCommand(
+		String paymentKey, String orderId, PaymentStatus paymentStatus) {
+
+	public PaymentStatusUpdateCommand(
+			String paymentKey, String orderId, PaymentStatus paymentStatus) {
+		validateObjectsNonnull(paymentKey, orderId, paymentStatus);
+		this.paymentKey = paymentKey;
+		this.orderId = orderId;
+		this.paymentStatus = paymentStatus;
+	}
+
+	private void validateObjectsNonnull(
+			String paymentKey, String orderId, PaymentStatus paymentStatus) {
+		Objects.requireNonNull(paymentKey, "paymentKey 가 null 인 결제의 상태 변경은 불가능합니다.");
+		Objects.requireNonNull(orderId, "orderId 가 null 인 결제의 상태 변경은 불가능합니다.");
+		Objects.requireNonNull(paymentStatus, "paymentStatus 가 null 인 결제 상태 변경은 불가능합니다.");
+	}
+}

--- a/src/main/java/com/ordertogether/team14_be/payment/web/controller/PaymentController.java
+++ b/src/main/java/com/ordertogether/team14_be/payment/web/controller/PaymentController.java
@@ -1,8 +1,11 @@
 package com.ordertogether.team14_be.payment.web.controller;
 
 import com.ordertogether.team14_be.common.web.response.ApiResponse;
+import com.ordertogether.team14_be.payment.service.PaymentConfirmService;
 import com.ordertogether.team14_be.payment.service.PaymentPreparationService;
+import com.ordertogether.team14_be.payment.web.request.PaymentConfirmRequest;
 import com.ordertogether.team14_be.payment.web.request.PaymentPrepareRequest;
+import com.ordertogether.team14_be.payment.web.response.PaymentConfirmationResponse;
 import com.ordertogether.team14_be.payment.web.response.PaymentPrepareResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -18,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class PaymentController {
 
 	private final PaymentPreparationService paymentPreparationService;
+	private final PaymentConfirmService paymentConfirmService;
 
 	@PostMapping
 	public ResponseEntity<ApiResponse<PaymentPrepareResponse>> preparePayment(
@@ -27,5 +31,16 @@ public class PaymentController {
 		PaymentPrepareResponse data = paymentPreparationService.prepare(request);
 
 		return ResponseEntity.ok(ApiResponse.with(HttpStatus.OK, "결제 정보를 저장하였습니다.", data));
+	}
+
+	@PostMapping("/confirm")
+	public ResponseEntity<ApiResponse<PaymentConfirmationResponse>> confirmPayment(
+			@RequestBody PaymentConfirmRequest request) {
+		PaymentConfirmationResponse data = paymentConfirmService.confirm(request);
+		if (data.paymentStatus().isFail()) {
+			return ResponseEntity.badRequest()
+					.body(ApiResponse.with(HttpStatus.BAD_REQUEST, "결제에 실패하였습니다.", data));
+		}
+		return ResponseEntity.ok(ApiResponse.with(HttpStatus.OK, "결제가 완료되었습니다.", data));
 	}
 }

--- a/src/main/java/com/ordertogether/team14_be/payment/web/controller/PaymentViewController.java
+++ b/src/main/java/com/ordertogether/team14_be/payment/web/controller/PaymentViewController.java
@@ -1,0 +1,40 @@
+package com.ordertogether.team14_be.payment.web.controller;
+
+import com.ordertogether.team14_be.payment.service.PaymentPreparationService;
+import com.ordertogether.team14_be.payment.web.request.PaymentPrepareRequest;
+import com.ordertogether.team14_be.payment.web.response.PaymentPrepareResponse;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+@RequiredArgsConstructor
+public class PaymentViewController {
+
+	private final PaymentPreparationService paymentPreparationService;
+
+	@GetMapping("/success")
+	public String successPage() {
+		return "success";
+	}
+
+	@GetMapping("/fail")
+	public String failPage() {
+		return "fail";
+	}
+
+	@GetMapping("/")
+	public String preparePayment(Model model) {
+		PaymentPrepareResponse response =
+				paymentPreparationService.prepare(
+						new PaymentPrepareRequest(UUID.randomUUID().toString(), List.of(1L, 2L))
+								.addBuyerId(1L));
+
+		model.addAttribute("orderId", response.orderId());
+		model.addAttribute("orderName", response.orderName());
+		return "checkout";
+	}
+}

--- a/src/main/java/com/ordertogether/team14_be/payment/web/request/PaymentConfirmRequest.java
+++ b/src/main/java/com/ordertogether/team14_be/payment/web/request/PaymentConfirmRequest.java
@@ -1,0 +1,6 @@
+package com.ordertogether.team14_be.payment.web.request;
+
+import lombok.Builder;
+
+@Builder
+public record PaymentConfirmRequest(String orderId, String paymentKey, Long amount) {}

--- a/src/main/java/com/ordertogether/team14_be/payment/web/response/PaymentConfirmationFailure.java
+++ b/src/main/java/com/ordertogether/team14_be/payment/web/response/PaymentConfirmationFailure.java
@@ -1,0 +1,3 @@
+package com.ordertogether.team14_be.payment.web.response;
+
+public record PaymentConfirmationFailure(String code, String message) {}

--- a/src/main/java/com/ordertogether/team14_be/payment/web/response/PaymentConfirmationResponse.java
+++ b/src/main/java/com/ordertogether/team14_be/payment/web/response/PaymentConfirmationResponse.java
@@ -1,0 +1,20 @@
+package com.ordertogether.team14_be.payment.web.response;
+
+import com.ordertogether.team14_be.payment.domain.PaymentStatus;
+import jakarta.annotation.Nullable;
+import java.util.Objects;
+
+public record PaymentConfirmationResponse(
+		PaymentStatus paymentStatus, @Nullable PaymentConfirmationFailure failure) {
+
+	public PaymentConfirmationResponse(
+			PaymentStatus paymentStatus, PaymentConfirmationFailure failure) {
+		if (paymentStatus.isFail()) {
+			Objects.requireNonNull(
+					failure, "결제 상태가 FAIL 인 경우, PaymentConfirmationFailure 가 null 일 수 없습니다.");
+		}
+
+		this.paymentStatus = paymentStatus;
+		this.failure = failure;
+	}
+}

--- a/src/main/java/com/ordertogether/team14_be/payment/web/toss/client/TossPaymentsClient.java
+++ b/src/main/java/com/ordertogether/team14_be/payment/web/toss/client/TossPaymentsClient.java
@@ -1,0 +1,53 @@
+package com.ordertogether.team14_be.payment.web.toss.client;
+
+import com.ordertogether.team14_be.payment.domain.PaymentStatus;
+import com.ordertogether.team14_be.payment.web.request.PaymentConfirmRequest;
+import com.ordertogether.team14_be.payment.web.response.PaymentConfirmationFailure;
+import com.ordertogether.team14_be.payment.web.response.PaymentConfirmationResponse;
+import com.ordertogether.team14_be.payment.web.toss.response.TossPaymentsConfirmationResponse;
+import java.io.IOException;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClient.RequestHeadersSpec.ConvertibleClientHttpResponse;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class TossPaymentsClient {
+
+	private final RestClient tossRestClient;
+	private static final String URI = "/v1/payments/confirm";
+	private static final String IDEMPOTENCY_HEADER_KEY = "Idempotency-Key";
+
+	public PaymentConfirmationResponse confirmPayment(PaymentConfirmRequest request) {
+		return tossRestClient
+				.post()
+				.uri(URI)
+				.header(IDEMPOTENCY_HEADER_KEY, request.paymentKey())
+				.body(request)
+				.exchange(
+						(req, res) -> {
+							TossPaymentsConfirmationResponse tossResponse =
+									res.bodyTo(TossPaymentsConfirmationResponse.class);
+
+							return new PaymentConfirmationResponse(
+									getPaymentStatus(res), getFailure(tossResponse));
+						});
+	}
+
+	private static PaymentStatus getPaymentStatus(ConvertibleClientHttpResponse res)
+			throws IOException {
+		return res.getStatusCode().isError() ? PaymentStatus.FAIL : PaymentStatus.SUCCESS;
+	}
+
+	private static PaymentConfirmationFailure getFailure(
+			TossPaymentsConfirmationResponse tossResponse) {
+		return Objects.isNull(tossResponse.failure())
+				? null
+				: new PaymentConfirmationFailure(
+						tossResponse.failure().code(), tossResponse.failure().message());
+	}
+}

--- a/src/main/java/com/ordertogether/team14_be/payment/web/toss/config/TossPaymentsClientConfig.java
+++ b/src/main/java/com/ordertogether/team14_be/payment/web/toss/config/TossPaymentsClientConfig.java
@@ -1,0 +1,30 @@
+package com.ordertogether.team14_be.payment.web.toss.config;
+
+import java.util.Base64;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.client.RestClient;
+
+@ConfigurationProperties(prefix = "pg.toss")
+@RequiredArgsConstructor
+public class TossPaymentsClientConfig {
+
+	private final String secretKey;
+	private final String url;
+
+	@Bean
+	public RestClient tossRestClient(RestClient.Builder builder) {
+		return builder
+				.defaultHeader(HttpHeaders.AUTHORIZATION, getBasicAuthorization())
+				.defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+				.baseUrl(url)
+				.build();
+	}
+
+	private String getBasicAuthorization() {
+		return "Basic " + Base64.getEncoder().encodeToString((secretKey + ":").getBytes());
+	}
+}

--- a/src/main/java/com/ordertogether/team14_be/payment/web/toss/error/TossPaymentsError.java
+++ b/src/main/java/com/ordertogether/team14_be/payment/web/toss/error/TossPaymentsError.java
@@ -1,0 +1,59 @@
+package com.ordertogether.team14_be.payment.web.toss.error;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum TossPaymentsError {
+	ALREADY_PROCESSED_PAYMENT(400, "이미 처리된 결제 입니다."),
+	PROVIDER_ERROR(400, "일시적인 오류가 발생했습니다. 잠시 후 다시 시도해주세요."),
+	EXCEED_MAX_CARD_INSTALLMENT_PLAN(400, "설정 가능한 최대 할부 개월 수를 초과했습니다."),
+	INVALID_REQUEST(400, "잘못된 요청입니다."),
+	NOT_ALLOWED_POINT_USE(400, "포인트 사용이 불가한 카드로 카드 포인트 결제에 실패했습니다."),
+	INVALID_API_KEY(400, "잘못된 시크릿키 연동 정보 입니다."),
+	INVALID_REJECT_CARD(400, "카드 사용이 거절되었습니다. 카드사 문의가 필요합니다."),
+	BELOW_MINIMUM_AMOUNT(400, "신용카드는 결제금액이 100원 이상, 계좌는 200원이상부터 결제가 가능합니다."),
+	INVALID_CARD_EXPIRATION(400, "카드 정보를 다시 확인해주세요. (유효기간)"),
+	INVALID_STOPPED_CARD(400, "정지된 카드 입니다."),
+	EXCEED_MAX_DAILY_PAYMENT_COUNT(400, "하루 결제 가능 횟수를 초과했습니다."),
+	NOT_SUPPORTED_INSTALLMENT_PLAN_CARD_OR_MERCHANT(400, "할부가 지원되지 않는 카드 또는 가맹점 입니다."),
+	INVALID_CARD_INSTALLMENT_PLAN(400, "할부 개월 정보가 잘못되었습니다."),
+	NOT_SUPPORTED_MONTHLY_INSTALLMENT_PLAN(400, "할부가 지원되지 않는 카드입니다."),
+	EXCEED_MAX_PAYMENT_AMOUNT(400, "하루 결제 가능 금액을 초과했습니다."),
+	NOT_FOUND_TERMINAL_ID(400, "단말기번호(Terminal Id)가 없습니다. 토스페이먼츠로 문의 바랍니다."),
+	INVALID_AUTHORIZE_AUTH(400, "유효하지 않은 인증 방식입니다."),
+	INVALID_CARD_LOST_OR_STOLEN(400, "분실 혹은 도난 카드입니다."),
+	RESTRICTED_TRANSFER_ACCOUNT(400, "계좌는 등록 후 12시간 뒤부터 결제할 수 있습니다. 관련 정책은 해당 은행으로 문의해주세요."),
+	INVALID_CARD_NUMBER(400, "카드번호를 다시 확인해주세요."),
+	INVALID_UNREGISTERED_SUBMALL(400, "등록되지 않은 서브몰입니다. 서브몰이 없는 가맹점이라면 안심클릭이나 ISP 결제가 필요합니다."),
+	NOT_REGISTERED_BUSINESS(400, "등록되지 않은 사업자 번호입니다."),
+	EXCEED_MAX_ONE_DAY_WITHDRAW_AMOUNT(400, "1일 출금 한도를 초과했습니다."),
+	EXCEED_MAX_ONE_TIME_WITHDRAW_AMOUNT(400, "1회 출금 한도를 초과했습니다."),
+	CARD_PROCESSING_ERROR(400, "카드사에서 오류가 발생했습니다."),
+	EXCEED_MAX_AMOUNT(400, "거래금액 한도를 초과했습니다."),
+	INVALID_ACCOUNT_INFO_RE_REGISTER(400, "유효하지 않은 계좌입니다. 계좌 재등록 후 시도해주세요."),
+	NOT_AVAILABLE_PAYMENT(400, "결제가 불가능한 시간대입니다"),
+	UNAPPROVED_ORDER_ID(400, "아직 승인되지 않은 주문번호입니다."),
+	UNAUTHORIZED_KEY(401, "인증되지 않은 시크릿 키 혹은 클라이언트 키 입니다."),
+	REJECT_ACCOUNT_PAYMENT(403, "잔액부족으로 결제에 실패했습니다."),
+	REJECT_CARD_PAYMENT(403, "한도초과 혹은 잔액부족으로 결제에 실패했습니다."),
+	REJECT_CARD_COMPANY(403, "결제 승인이 거절되었습니다."),
+	FORBIDDEN_REQUEST(403, "허용되지 않은 요청입니다."),
+	REJECT_TOSSPAY_INVALID_ACCOUNT(403, "선택하신 출금 계좌가 출금이체 등록이 되어 있지 않아요. 계좌를 다시 등록해 주세요."),
+	EXCEED_MAX_AUTH_COUNT(403, "최대 인증 횟수를 초과했습니다. 카드사로 문의해주세요."),
+	EXCEED_MAX_ONE_DAY_AMOUNT(403, "일일 한도를 초과했습니다."),
+	NOT_AVAILABLE_BANK(403, "은행 서비스 시간이 아닙니다."),
+	INVALID_PASSWORD(403, "결제 비밀번호가 일치하지 않습니다."),
+	INCORRECT_BASIC_AUTH_FORMAT(403, "잘못된 요청입니다. ':' 를 포함해 인코딩해주세요."),
+	FDS_ERROR(
+			403, "[토스페이먼츠] 위험거래가 감지되어 결제가 제한됩니다. 발송된 문자에 포함된 링크를 통해 본인인증 후 결제가 가능합니다. (고객센터: 1644-8051)"),
+	NOT_FOUND_PAYMENT(404, "존재하지 않는 결제 정보 입니다."),
+	NOT_FOUND_PAYMENT_SESSION(404, "결제 시간이 만료되어 결제 진행 데이터가 존재하지 않습니다."),
+	FAILED_PAYMENT_INTERNAL_SYSTEM_PROCESSING(500, "결제가 완료되지 않았어요. 다시 시도해주세요."),
+	FAILED_INTERNAL_SYSTEM_PROCESSING(500, "내부 시스템 처리 작업이 실패했습니다. 잠시 후 다시 시도해주세요."),
+	UNKNOWN_PAYMENT_ERROR(500, "결제에 실패했어요. 같은 문제가 반복된다면 은행이나 카드사로 문의해주세요."),
+	UNKNOWN(500, "알 수 없는 에러입니다.");
+
+	private final Integer statusCode;
+
+	private final String description;
+}

--- a/src/main/java/com/ordertogether/team14_be/payment/web/toss/response/TossPaymentsConfirmationResponse.java
+++ b/src/main/java/com/ordertogether/team14_be/payment/web/toss/response/TossPaymentsConfirmationResponse.java
@@ -1,0 +1,104 @@
+package com.ordertogether.team14_be.payment.web.toss.response;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import lombok.Builder;
+
+@Builder
+public record TossPaymentsConfirmationResponse(
+		String version,
+		String paymentKey,
+		String type,
+		String orderId,
+		String orderName,
+		String mId,
+		String currency,
+		String method,
+		BigDecimal totalAmount,
+		BigDecimal balanceAmount,
+		String status,
+		String requestedAt,
+		String approvedAt,
+		boolean useEscrow,
+		String lastTransactionKey,
+		BigDecimal suppliedAmount,
+		BigDecimal vat,
+		boolean cultureExpense,
+		BigDecimal taxFreeAmount,
+		int taxExemptionAmount,
+		List<Cancel> cancels,
+		boolean expired,
+		boolean isPartialCancelable,
+		Card card,
+		VirtualAccount virtualAccount,
+		Transfer transfer,
+		CashReceipt cashReceipt,
+		List<CashReceipt> cashReceipts,
+		Metadata metadata,
+		String receiptUrl,
+		EasyPay easyPay,
+		String country,
+		Failure failure,
+		RefundReceiveAccount refundReceiveAccount) {
+
+	public static record Card(
+			BigDecimal amount,
+			String issuerCode,
+			String acquirerCode,
+			String number,
+			int installmentPlanMonths,
+			String approveNo,
+			boolean useCardPoint,
+			String cardType,
+			String ownerType,
+			String acquireStatus,
+			boolean isInterestFree,
+			String interestPayer) {}
+
+	public static record Cancel(
+			BigDecimal cancelAmount,
+			String cancelReason,
+			BigDecimal taxFreeAmount,
+			int taxExemptionAmount,
+			BigDecimal refundableAmount,
+			BigDecimal easyPayDiscountAmount,
+			String canceledAt,
+			String transactionKey,
+			String receiptKey,
+			String cancelStatus,
+			String cancelRequestId) {}
+
+	public static record CashReceipt(
+			String type,
+			String receiptKey,
+			String issueNumber,
+			String receiptUrl,
+			BigDecimal amount,
+			BigDecimal taxFreeAmount,
+			String businessNumber,
+			String transactionType,
+			String issueStatus,
+			String customerIdentityNumber,
+			String requestedAt) {}
+
+	public static record EasyPay(String provider, BigDecimal amount, BigDecimal discountAmount) {}
+
+	public static record Failure(String code, String message) {}
+
+	public static record Metadata(Map<String, String> metadata) {}
+
+	public static record RefundReceiveAccount(
+			String bankCode, String accountNumber, String holderName) {}
+
+	public static record Transfer(String bankCode, String settlementStatus) {}
+
+	public static record VirtualAccount(
+			String accountType,
+			String accountNumber,
+			String bankCode,
+			String customerName,
+			String dueDate,
+			String refundStatus,
+			boolean expired) {}
+}

--- a/src/main/java/com/ordertogether/team14_be/spot/controller/SpotController.java
+++ b/src/main/java/com/ordertogether/team14_be/spot/controller/SpotController.java
@@ -39,10 +39,10 @@ public class SpotController {
 	}
 
 	// 반경 n미터 내 Spot 조회하기
-	@GetMapping("/api/v1/spot/{lat}/{lng}/{radius}") // 현재 위치의 좌표와 반지름을 받아옴
-	public ResponseEntity<List<SpotViewedResponse>> getSpotByRadius(
-			@PathVariable BigDecimal lat, @PathVariable BigDecimal lng, @PathVariable int radius) {
-		return ResponseEntity.ok(spotService.getSpotByRadius(lat, lng, radius));
+	@GetMapping("/api/v1/spot/{lat}/{lng}") // 현재 위치의 좌표로 hash값이 같은 튜플을 조회
+	public ResponseEntity<List<SpotViewedResponse>> getSpotByGeoHash(
+			@PathVariable BigDecimal lat, @PathVariable BigDecimal lng) {
+		return ResponseEntity.ok(spotService.getSpotByGeoHash(lat, lng));
 	}
 
 	// Spot 수정하기

--- a/src/main/java/com/ordertogether/team14_be/spot/dto/controllerdto/SpotCreationRequest.java
+++ b/src/main/java/com/ordertogether/team14_be/spot/dto/controllerdto/SpotCreationRequest.java
@@ -3,6 +3,7 @@ package com.ordertogether.team14_be.spot.dto.controllerdto;
 import com.ordertogether.team14_be.spot.enums.Category;
 import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
+import java.time.LocalTime;
 
 public record SpotCreationRequest(
 		Long id,
@@ -12,4 +13,5 @@ public record SpotCreationRequest(
 		@NotNull(message = "카테고리를 선택해주세요") Category category,
 		@NotNull(message = "최소 주문 금액을 입력해주세요") Integer minimumOrderAmount,
 		@NotNull(message = "배달의 민족 함께 주문링크를 입력해주세요") String togetherOrderLink,
-		@NotNull(message = "픽업 장소를 입력해주세요") String pickUpLocation) {}
+		@NotNull(message = "픽업 장소를 입력해주세요") String pickUpLocation,
+		@NotNull(message = "주문 마감 시간을 입력해주세요") LocalTime deadlineTime) {}

--- a/src/main/java/com/ordertogether/team14_be/spot/dto/controllerdto/SpotCreationResponse.java
+++ b/src/main/java/com/ordertogether/team14_be/spot/dto/controllerdto/SpotCreationResponse.java
@@ -1,10 +1,12 @@
 package com.ordertogether.team14_be.spot.dto.controllerdto;
 
 import com.ordertogether.team14_be.spot.enums.Category;
+import java.time.LocalTime;
 
 public record SpotCreationResponse(
 		Long id,
 		Category category,
 		String storeName,
 		Integer minimumOrderAmount,
-		String pickUpLocation) {}
+		String pickUpLocation,
+		LocalTime deadlineTime) {}

--- a/src/main/java/com/ordertogether/team14_be/spot/dto/servicedto/SpotDto.java
+++ b/src/main/java/com/ordertogether/team14_be/spot/dto/servicedto/SpotDto.java
@@ -4,6 +4,7 @@ import com.ordertogether.team14_be.spot.enums.Category;
 import jakarta.persistence.Column;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import lombok.*;
 
 @Builder
@@ -25,6 +26,8 @@ public class SpotDto {
 	private String togetherOrderLink;
 	private String pickUpLocation;
 	private String deliveryStatus;
+	private LocalTime deadlineTime;
+	@Setter private String geoHash;
 	private boolean isDeleted;
 	private LocalDateTime createdAt;
 	private LocalDateTime modifiedAt;

--- a/src/main/java/com/ordertogether/team14_be/spot/entity/Spot.java
+++ b/src/main/java/com/ordertogether/team14_be/spot/entity/Spot.java
@@ -5,6 +5,7 @@ import com.ordertogether.team14_be.member.persistence.entity.Member;
 import com.ordertogether.team14_be.spot.enums.Category;
 import jakarta.persistence.*;
 import java.math.BigDecimal;
+import java.time.LocalTime;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.DynamicUpdate;
@@ -42,6 +43,8 @@ public class Spot extends BaseEntity {
 
 	private String pickUpLocation;
 	private String deliveryStatus;
+	private LocalTime deadlineTime;
+	private String geoHash;
 	@Builder.Default private Boolean isDeleted = false;
 
 	public void delete() {

--- a/src/main/java/com/ordertogether/team14_be/spot/exception/ErrorResponse.java
+++ b/src/main/java/com/ordertogether/team14_be/spot/exception/ErrorResponse.java
@@ -2,5 +2,5 @@ package com.ordertogether.team14_be.spot.exception;
 
 import com.ordertogether.team14_be.spot.enums.ErrorCode;
 
-// @Getter
+
 public record ErrorResponse(String message, ErrorCode code) {}

--- a/src/main/java/com/ordertogether/team14_be/spot/repository/SimpleSpotRepository.java
+++ b/src/main/java/com/ordertogether/team14_be/spot/repository/SimpleSpotRepository.java
@@ -22,4 +22,6 @@ public interface SimpleSpotRepository extends JpaRepository<Spot, Long> {
 			@Param("maxlng") BigDecimal maxlng,
 			@Param("minlat") BigDecimal minlat,
 			@Param("minlng") BigDecimal minlng);
+
+	List<Spot> findByGeoHash(String geoHash);
 }

--- a/src/main/java/com/ordertogether/team14_be/spot/repository/SpotRepository.java
+++ b/src/main/java/com/ordertogether/team14_be/spot/repository/SpotRepository.java
@@ -41,10 +41,9 @@ public class SpotRepository {
 		spot.delete();
 	}
 
-	public List<SpotDto> findAroundSpotAndIsDeletedFalse(
-			BigDecimal maxX, BigDecimal maxY, BigDecimal minX, BigDecimal minY) {
-		List<Spot> spots = simpleSpotRepository.findAroundSpotAndIsDeletedFalse(maxX, maxY, minX, minY);
-
-		return spots.stream().map(SpotMapper.INSTANCE::toDto).toList();
+	public List<SpotDto> findBygeoHash(String geoHash) {
+		return simpleSpotRepository.findByGeoHash(geoHash).stream()
+				.map(SpotMapper.INSTANCE::toDto)
+				.toList();
 	}
 }

--- a/src/main/java/com/ordertogether/team14_be/spot/service/SpotService.java
+++ b/src/main/java/com/ordertogether/team14_be/spot/service/SpotService.java
@@ -1,7 +1,6 @@
 package com.ordertogether.team14_be.spot.service;
 
-import static java.lang.Math.abs;
-
+import ch.hsr.geohash.GeoHash;
 import com.ordertogether.team14_be.spot.dto.controllerdto.SpotCreationResponse;
 import com.ordertogether.team14_be.spot.dto.controllerdto.SpotDetailResponse;
 import com.ordertogether.team14_be.spot.dto.controllerdto.SpotViewedResponse;
@@ -18,7 +17,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class SpotService {
-	public static final int EARTH_RADIUS = 6371000; // 6371km
 	private final SpotRepository spotRepository;
 
 	// Spot 전체 조회하기
@@ -31,6 +29,10 @@ public class SpotService {
 
 	@Transactional
 	public SpotCreationResponse createSpot(SpotDto spotDto) {
+		BigDecimal lat = spotDto.getLat();
+		BigDecimal lng = spotDto.getLng();
+		GeoHash geoHash = GeoHash.withCharacterPrecision(lat.doubleValue(), lng.doubleValue(), 12);
+		spotDto.setGeoHash(geoHash.toBase32());
 		Spot spot = SpotMapper.INSTANCE.toEntity(spotDto, new Spot());
 		return SpotMapper.INSTANCE.toSpotCreationResponse(spotRepository.save(spot));
 	}
@@ -42,42 +44,16 @@ public class SpotService {
 		return SpotMapper.INSTANCE.toSpotDetailResponse(spotDto);
 	}
 
-	// 반경 n미터 내 Spot 조회하기
 	@Transactional(readOnly = true)
-	public List<SpotViewedResponse> getSpotByRadius(BigDecimal lat, BigDecimal lng, int radius) {
-		// m당 y 좌표 이동 값
-		double mForLatitude = (1 / (EARTH_RADIUS * 1 * (Math.PI / 180))) / 1000;
-		// m당 x 좌표 이동 값
-		double mForLongitude =
-				(1 / (EARTH_RADIUS * 1 * (Math.PI / 180) * Math.cos(Math.toRadians(lat.doubleValue()))))
-						/ 1000;
+	public List<SpotViewedResponse> getSpotByGeoHash(BigDecimal lat, BigDecimal lng) {
+		int precision = 12;
+		GeoHash geoHash =
+				GeoHash.withCharacterPrecision(lat.doubleValue(), lng.doubleValue(), precision);
 
-		// 현재 위치 기준 검색 거리 좌표
-		double maxY = lat.doubleValue() + (radius * mForLatitude);
-		double minY = lat.doubleValue() - (radius * mForLatitude);
-		double maxX = lng.doubleValue() + (radius * mForLongitude);
-		double minX = lng.doubleValue() - (radius * mForLongitude);
+		String hashString = geoHash.toBase32();
 
-		// 원의 지름에 해당하는 정사각형 내에 있는 Spot들을 모두 가져옴
-		List<SpotDto> resultAroundSpot =
-				spotRepository.findAroundSpotAndIsDeletedFalse(
-						BigDecimal.valueOf(maxX),
-						BigDecimal.valueOf(maxY),
-						BigDecimal.valueOf(minX),
-						BigDecimal.valueOf(minY));
-
-		// 자기 위치에서부터 반경 내에 있는 Spot만 반환
-		return resultAroundSpot.stream()
-				.filter(
-						spotDto -> {
-							double distance =
-									Math.sqrt(
-											Math.pow(abs(spotDto.getLat().doubleValue() - lat.doubleValue()), 2)
-													+ Math.pow(abs(spotDto.getLng().doubleValue() - lng.doubleValue()), 2));
-							return distance <= radius;
-						})
-				.map(SpotMapper.INSTANCE::toSpotViewedResponse)
-				.toList();
+		List<SpotDto> resultAroundSpot = spotRepository.findBygeoHash(hashString);
+		return resultAroundSpot.stream().map(SpotMapper.INSTANCE::toSpotViewedResponse).toList();
 	}
 
 	@Transactional

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,6 +40,11 @@ kakao:
     api:
       url: ${KAKAO_USER_API_URL}
 
+pg:
+  toss:
+    secret-key: test_gsk_docs_OaPz8L5KdmQXkzRz3y47BMw6
+    url: https://api.tosspayments.com
+
 key:
   jwt:
     secret-key: ${JWT_SECRET_KEY}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,3 +1,5 @@
+INSERT INTO member (id, email, point, phone_number, delivery_name, platform) VALUES (1, 'member1@example.com', 100000, '010-1234-5678', 'John Doe', 'Kakao');
+
 INSERT INTO product (id, name, price, created_at, modified_at, created_by, modified_by) VALUES (1, 'Product 1', 10000, now(), now(), 1, 1);
 INSERT INTO product (id, name, price, created_at, modified_at, created_by, modified_by) VALUES (2, 'Product 2', 20000, now(), now(), 1, 1);
 INSERT INTO product (id, name, price, created_at, modified_at, created_by, modified_by) VALUES (3, 'Product 3', 30000, now(), now(), 1, 1);

--- a/src/main/resources/static/style.css
+++ b/src/main/resources/static/style.css
@@ -1,0 +1,251 @@
+body {
+    background-image: url('https://static.toss.im/ml-illust/img-back_005.jpg');
+}
+.p {
+    padding: 0;
+    margin: 0;
+    font-family: Toss Product Sans, -apple-system, BlinkMacSystemFont,
+    Bazier Square, Noto Sans KR, Segoe UI, Apple SD Gothic Neo, Roboto,
+    Helvetica Neue, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji,
+    Segoe UI Symbol, Noto Color Emoji;
+    color: #4e5968;
+    word-break: keep-all;
+    word-wrap: break-word;
+}
+.h4 {
+    font-size: 20px;
+    font-weight: 700;
+    color: #333D4B;
+}
+.wrapper {
+    max-width: 800px;
+    margin: 0 auto;
+}
+.button {
+    color: #f9fafb;
+    background-color: #3182f6;
+    margin: 0;
+    font-size: 15px;
+    font-weight: 400;
+    line-height: 18px;
+    white-space: nowrap;
+    text-align: center;
+    /* vertical-align: middle; */
+    cursor: pointer;
+    border: 0 solid transparent;
+    user-select: none;
+    transition: background 0.2s ease, color 0.1s ease;
+    text-decoration: none;
+    border-radius: 7px;
+    padding: 11px 16px;
+}
+.button:hover {
+    color: #fff;
+    background-color: #1b64da;
+}
+.title {
+    margin: 0 0 4px;
+    font-size: 24px;
+    font-weight: 600;
+    color: #4e5968;
+}
+.result {
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    text-wrap: balance;
+}
+.box_section {
+    background-color: white;
+    border-radius: 10px;
+    box-shadow: 0 10px 20px rgb(0 0 0 / 1%), 0 6px 6px rgb(0 0 0 / 6%);
+    padding: 40px 30px 50px 30px;
+    margin-top:30px;
+    margin-bottom:50px;
+    color: #333D4B
+}
+:root {
+    --checkable-size: 20px;
+    --checkable-input-top: 3px;
+    --checkable-input-left: 5px;
+    --checkable-input-width: 14px;
+    --checkable-input-height: 10px;
+    --checkable-input-svg: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1.343 4.574l4.243 4.243 7.07-7.071' fill='transparent' stroke-width='2' stroke='%23FFF' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+    --checkable-label-text-padding: 8px;
+    --indeterminate-checkable-input-top: 7px;
+    --indeterminate-checkable-input-left: 5px;
+    --indeterminate-checkable-input-width: 14px
+}
+
+:root .checkable--small {
+    --checkable-size: 20px;
+    --checkable-input-top: 2px;
+    --checkable-input-left: 4px;
+    --checkable-input-width: 12px;
+    --checkable-input-height: 9px;
+    --checkable-input-svg: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1.286 3.645l3.536 3.536 5.892-5.893' fill='transparent' stroke-width='2' stroke='%23FFF' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+    --indeterminate-checkable-input-top: 5px;
+    --indeterminate-checkable-input-left: 4px;
+    --indeterminate-checkable-input-width: 12px
+}
+
+.checkable {
+    position: relative;
+    display: flex
+}
+
+.checkable+.checkable {
+    margin-top: 12px
+}
+
+.checkable--inline {
+    display: inline-block
+}
+
+.checkable--inline+.checkable--inline {
+    margin-top: 0;
+    margin-left: 18px
+}
+
+.checkable__label {
+    display: inline-block;
+    max-width: 100%;
+    min-height: 20px;
+    min-height: var(--checkable-size);
+    line-height: 1.6;
+    padding-left: 20px;
+    padding-left: var(--checkable-size);
+    margin-bottom: 0;
+    padding-top: 0;
+    padding-bottom: 0;
+    color: #4e5968;
+    color: var(--grey700);
+    cursor: pointer
+}
+
+.checkable__input {
+    position: absolute;
+    margin: 0 0 0 -20px;
+    margin: 0 0 0 calc(var(--checkable-size)*-1);
+    top: 4px;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    border: none;
+    cursor: pointer
+}
+
+.checkable__input:after,.checkable__input:before {
+    content: "";
+    position: absolute
+}
+
+.checkable__input:before {
+    top: -4px;
+    left: 0;
+    width: 20px;
+    width: var(--checkable-size);
+    height: 20px;
+    height: var(--checkable-size);
+    border: 2px solid #d1d6db;
+    border: 2px solid #d1d6db;
+    background-color: #fff;
+    background-color: white;
+    transition: border-color .1s ease,background-color .1s ease
+}
+
+.checkable__input:after {
+    opacity: 0;
+    transition: opacity .1s ease;
+    top: 3px;
+    top: var(--checkable-input-top);
+    left: 5px;
+    left: var(--checkable-input-left);
+    width: 14px;
+    width: var(--checkable-input-width);
+    height: 10px;
+    height: var(--checkable-input-height);
+    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1.343 4.574l4.243 4.243 7.07-7.071' fill='transparent' stroke-width='2' stroke='%23FFF' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+    background-image: var(--checkable-input-svg);
+    background-repeat: no-repeat
+}
+
+.checkable__input[type=checkbox]:indeterminate:after {
+    top: 7px;
+    top: var(--indeterminate-checkable-input-top);
+    left: 5px;
+    left: var(--indeterminate-checkable-input-left);
+    width: 14px;
+    width: var(--indeterminate-checkable-input-width);
+    height: 0;
+    border: 1px solid #fff;
+    border: 1px solid var(--white);
+    border-radius: 1px;
+    transform: rotate(0)
+}
+
+.checkable__input:focus {
+    outline: 0
+}
+
+.checkable__input:focus:before,.checkable__input:hover:before {
+    background-color: #e8f3ff;
+    background-color: #e8f3ff;
+    border-color: #3182f6;
+    border-color: #3182f6
+}
+
+.checkable__input:checked:before,.checkable__input[type=checkbox]:indeterminate:before {
+    border-color: #3182f6;
+    border-color: #3182f6;
+    background-color: #3182f6;
+    background-color: #3182f6
+}
+
+.checkable__input:checked:after,.checkable__input[type=checkbox]:indeterminate:after {
+    opacity: 1
+}
+
+.checkable__input:disabled:before {
+    background-color: #f2f4f6;
+    background-color: var(--grey100);
+    border-color: rgba(0,23,51,.02);
+    border-color: var(--greyOpacity50)
+}
+
+.checkable__input:disabled:checked:before,.checkable__input:disabled[type=checkbox]:indeterminate:before {
+    background-color: #e5e8eb;
+    background-color: var(--grey200);
+    border-color: #e5e8eb;
+    border-color: var(--grey200)
+}
+
+.checkable__input[type=checkbox]:before {
+    border-radius: 6px
+}
+
+.checkable__input[type=radio]:before {
+    border-radius: 12px
+}
+
+.checkable__label-text {
+    display: inline-block;
+    padding-left: 13px;
+    color: #4e5968;
+
+    /* padding-left: var(--checkable-label-text-padding) */
+}
+
+.checkable--disabled>.checkable__input {
+    cursor: not-allowed
+}
+
+.checkable--disabled>.checkable__label {
+    color: #b0b8c1;
+    color: var(--grey400);
+    cursor: not-allowed
+}
+
+.checkable--read-only {
+    pointer-events: none
+}

--- a/src/main/resources/templates/checkout.html
+++ b/src/main/resources/templates/checkout.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="https://static.toss.im/icons/png/4x/icon-toss-logo.png" />
+    <link rel="stylesheet" type="text/css" href="/style.css" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>토스페이먼츠 샘플 프로젝트</title>
+    <!-- SDK 추가 -->
+    <script src="https://js.tosspayments.com/v2/standard"></script>
+</head>
+
+<body>
+<!-- 주문서 영역 -->
+<div class="wrapper">
+    <div class="box_section" style="padding: 40px 30px 50px 30px; margin-top: 30px; margin-bottom: 50px">
+        <!-- 결제 UI -->
+        <div id="payment-method"></div>
+        <!-- 이용약관 UI -->
+        <div id="agreement"></div>
+        <!-- 쿠폰 체크박스 -->
+        <div style="padding-left: 30px">
+            <div class="checkable typography--p">
+                <label for="coupon-box" class="checkable__label typography--regular"
+                ><input id="coupon-box" class="checkable__input" type="checkbox" aria-checked="true" /><span class="checkable__label-text">5,000원 쿠폰 적용</span></label
+                >
+            </div>
+        </div>
+        <!-- 결제하기 버튼 -->
+        <button class="button" id="payment-button" style="margin-top: 30px">결제하기</button>
+    </div>
+    <div class="box_section" style="padding: 40px 30px 50px 30px; margin-top: 30px; margin-bottom: 50px">
+        <!-- 브랜드페이만 연동하기 -->
+        <button class="button" id="brandpay-button" style="margin-top: 30px">위젯 없이 브랜드페이만 연동하기</button>
+        <!-- 결제창만 연동하기 -->
+        <button class="button" id="payment-window-button" style="margin-top: 30px">위젯 없이 결제창만 연동하기</button>
+    </div>
+</div>
+<script>
+    main();
+
+    async function main() {
+        const button = document.getElementById("payment-button");
+        const coupon = document.getElementById("coupon-box");
+
+        const generateRandomString = () => window.btoa(Math.random()).slice(0, 20);
+
+        const amount = {
+            currency: "KRW",
+            value: 30000,
+        };
+
+        // /*<![CDATA[*/
+        const orderId = "[[${orderId}]]"
+        const orderName = "[[${orderName}]]"
+        // var amount = [[${amount}]]
+        // /*]]>*/
+        //
+        console.log("orderId: " + orderId)
+        console.log("orderName: " + orderName)
+        console.log("amount: " + amount)
+        // ------  결제위젯 초기화 ------
+        // TODO: clientKey는 개발자센터의 결제위젯 연동 키 > 클라이언트 키로 바꾸세요.
+        // TODO: 구매자의 고유 아이디를 불러와서 customerKey로 설정하세요. 이메일・전화번호와 같이 유추가 가능한 값은 안전하지 않습니다.
+        // @docs https://docs.tosspayments.com/sdk/v2/js#토스페이먼츠-초기화
+        const clientKey = "test_gck_docs_Ovk5rk1EwkEbP0W43n07xlzm";
+        const customerKey = generateRandomString();
+        const tossPayments = TossPayments(clientKey);
+        // 회원 결제
+        // @docs https://docs.tosspayments.com/sdk/v2/js#tosspaymentswidgets
+        const widgets = tossPayments.widgets({
+            customerKey,
+        });
+        // 비회원 결제
+        // const widgets = tossPayments.widgets({customerKey: TossPayments.ANONYMOUS});
+
+        // ------  주문서의 결제 금액 설정 ------
+        // TODO: 위젯의 결제금액을 결제하려는 금액으로 초기화하세요.
+        // TODO: renderPaymentMethods, renderAgreement, requestPayment 보다 반드시 선행되어야 합니다.
+        // @docs https://docs.tosspayments.com/sdk/v2/js#widgetssetamount
+        await widgets.setAmount(amount);
+
+        await Promise.all([
+            // ------  결제 UI 렌더링 ------
+            // @docs https://docs.tosspayments.com/sdk/v2/js#widgetsrenderpaymentmethods
+            widgets.renderPaymentMethods({
+                selector: "#payment-method",
+                // 렌더링하고 싶은 결제 UI의 variantKey
+                // 결제 수단 및 스타일이 다른 멀티 UI를 직접 만들고 싶다면 계약이 필요해요.
+                // @docs https://docs.tosspayments.com/guides/v2/payment-widget/admin#새로운-결제-ui-추가하기
+                variantKey: "DEFAULT",
+            }),
+            // ------  이용약관 UI 렌더링 ------
+            // @docs https://docs.tosspayments.com/sdk/v2/js#widgetsrenderagreement
+            widgets.renderAgreement({
+                selector: "#agreement",
+                variantKey: "AGREEMENT",
+            }),
+        ]);
+
+        // ------  주문서의 결제 금액이 변경되었을 경우 결제 금액 업데이트 ------
+        // @docs https://docs.tosspayments.com/sdk/v2/js#widgetssetamount
+        coupon.addEventListener("change", async function () {
+            if (coupon.checked) {
+                await widgets.setAmount({
+                    currency: "KRW",
+                    value: amount.value - 5000,
+                });
+
+                return;
+            }
+
+            await widgets.setAmount({
+                currency: "KRW",
+                value: amount.value,
+            });
+        });
+
+        // ------ '결제하기' 버튼 누르면 결제창 띄우기 ------
+        // @docs https://docs.tosspayments.com/sdk/v2/js#widgetsrequestpayment
+        button.addEventListener("click", async function () {
+            // 결제를 요청하기 전에 orderId, amount를 서버에 저장하세요.
+            // 결제 과정에서 악의적으로 결제 금액이 바뀌는 것을 확인하는 용도입니다.
+            await widgets.requestPayment({
+                orderId: orderId,
+                orderName: "토스 티셔츠 외 2건",
+                successUrl: window.location.origin + "/success",
+                failUrl: window.location.origin + "/fail",
+                customerEmail: "customer123@gmail.com",
+                customerName: "김토스",
+                customerMobilePhone: "01012341234",
+            });
+        });
+    }
+
+    document.getElementById("payment-window-button").addEventListener("click", () => {
+        location.href = "/payment/checkout.html";
+    });
+
+    document.getElementById("brandpay-button").addEventListener("click", () => {
+        location.href = "/brandpay/checkout.html";
+    });
+
+</script>
+</body>
+</html>

--- a/src/main/resources/templates/fail.html
+++ b/src/main/resources/templates/fail.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="https://static.toss.im/icons/png/4x/icon-toss-logo.png" />
+    <link th:href="@{/style.css}" rel="stylesheet" type="text/css"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>토스페이먼츠 샘플 프로젝트</title>
+</head>
+
+<body>
+<div class="result wrapper">
+    <div class="box_section">
+        <h2 style="padding: 20px 0px 10px 0px">
+            <img width="25px" src="https://static.toss.im/3d-emojis/u1F6A8-apng.png" />
+            결제 실패
+        </h2>
+        <p id="code"></p>
+        <p id="message"></p>
+    </div>
+</div>
+</body>
+</html>
+
+<script>
+    const urlParams = new URLSearchParams(window.location.search);
+
+    const codeElement = document.getElementById("code");
+    const messageElement = document.getElementById("message");
+
+    codeElement.textContent = "에러코드: " + urlParams.get("code");
+    messageElement.textContent = "실패 사유: " + urlParams.get("message");
+</script>

--- a/src/main/resources/templates/success.html
+++ b/src/main/resources/templates/success.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="https://static.toss.im/icons/png/4x/icon-toss-logo.png" />
+    <link th:href="@{/style.css}" rel="stylesheet" type="text/css"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>토스페이먼츠 샘플 프로젝트</title>
+</head>
+<body>
+<div class="result wrapper">
+    <div class="box_section">
+        <h2 style="padding: 20px 0px 10px 0px">
+            <img width="35px" src="https://static.toss.im/3d-emojis/u1F389_apng.png" />
+            결제 성공
+        </h2>
+
+        <p id="paymentKey"></p>
+        <p id="orderId"></p>
+        <p id="amount"></p>
+    </div>
+</div>
+<script>
+    // 쿼리 파라미터 값이 결제 요청할 때 보낸 데이터와 동일한지 반드시 확인하세요.
+    // 클라이언트에서 결제 금액을 조작하는 행위를 방지할 수 있습니다.
+    const urlParams = new URLSearchParams(window.location.search);
+
+    // 서버로 결제 승인에 필요한 결제 정보를 보내세요.
+    async function confirm() {
+        var requestData = {
+            paymentKey: urlParams.get("paymentKey"),
+            orderId: urlParams.get("orderId"),
+            amount: urlParams.get("amount"),
+        };
+
+        const response = await fetch("/api/v1/payments/confirm", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify(requestData),
+        });
+
+        const json = await response.json();
+
+        if (!response.ok) {
+            // TODO: 결제 실패 비즈니스 로직을 구현하세요.
+            console.log(json);
+            window.location.href = `/fail?message=${json.message}&code=${json.code}`;
+        }
+
+        // TODO: 결제 성공 비즈니스 로직을 구현하세요.
+        console.log(json);
+    }
+    confirm();
+
+    const paymentKeyElement = document.getElementById("paymentKey");
+    const orderIdElement = document.getElementById("orderId");
+    const amountElement = document.getElementById("amount");
+
+    orderIdElement.textContent = "주문번호: " + urlParams.get("orderId");
+    amountElement.textContent = "결제 금액: " + urlParams.get("amount");
+    paymentKeyElement.textContent = "paymentKey: " + urlParams.get("paymentKey");
+</script>
+</body>
+</html>

--- a/src/test/java/com/ordertogether/team14_be/helper/PaymentDatabaseHelper.java
+++ b/src/test/java/com/ordertogether/team14_be/helper/PaymentDatabaseHelper.java
@@ -3,4 +3,8 @@ package com.ordertogether.team14_be.helper;
 public interface PaymentDatabaseHelper {
 
 	void clean();
+
+	void saveTestData();
+
+	void setOrderId(String orderId);
 }

--- a/src/test/java/com/ordertogether/team14_be/helper/jpa/JpaPaymentDatabaseHelper.java
+++ b/src/test/java/com/ordertogether/team14_be/helper/jpa/JpaPaymentDatabaseHelper.java
@@ -1,17 +1,92 @@
 package com.ordertogether.team14_be.helper.jpa;
 
 import com.ordertogether.team14_be.helper.PaymentDatabaseHelper;
+import com.ordertogether.team14_be.member.persistence.MemberRepository;
+import com.ordertogether.team14_be.member.persistence.entity.Member;
+import com.ordertogether.team14_be.payment.domain.PaymentEvent;
+import com.ordertogether.team14_be.payment.domain.PaymentOrder;
+import com.ordertogether.team14_be.payment.domain.PaymentStatus;
+import com.ordertogether.team14_be.payment.domain.Product;
+import com.ordertogether.team14_be.payment.persistence.repository.PaymentEventRepository;
+import com.ordertogether.team14_be.payment.persistence.repository.PaymentOrderRepository;
+import com.ordertogether.team14_be.payment.persistence.repository.ProductRepository;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
 public class JpaPaymentDatabaseHelper implements PaymentDatabaseHelper {
 
 	private final JpaDatabaseCleanup jpaDatabaseCleanup;
+	private final PaymentEventRepository paymentEventRepository;
+	private final PaymentOrderRepository paymentOrderRepository;
+	private final ProductRepository productRepository;
+	private final MemberRepository memberRepository;
+
+	private String orderId;
 
 	@Override
 	public void clean() {
 		jpaDatabaseCleanup.execute();
+	}
+
+	@Override
+	@Transactional
+	public void saveTestData() {
+		if (Objects.isNull(orderId)) {
+			throw new IllegalStateException("orderId is not set");
+		}
+		memberRepository.save(
+				new Member(1L, "member1@example.com", 100000, "010-1234-5678", "member1", "Kakao"));
+
+		productRepository.saveAll(
+				List.of(
+						Product.builder().id(1L).name("Product 1").price(BigDecimal.valueOf(10000)).build(),
+						Product.builder().id(2L).name("Product 2").price(BigDecimal.valueOf(20000)).build(),
+						Product.builder().id(3L).name("Product 3").price(BigDecimal.valueOf(30000)).build()));
+
+		List<PaymentOrder> paymentOrders =
+				paymentOrderRepository.saveAll(
+						List.of(
+								PaymentOrder.builder()
+										.id(1L)
+										.productId(1L)
+										.orderId(orderId)
+										.orderName("Product 1")
+										.amount(BigDecimal.valueOf(10000L))
+										.build(),
+								PaymentOrder.builder()
+										.id(2L)
+										.productId(2L)
+										.orderId(orderId)
+										.orderName("Product 2")
+										.amount(BigDecimal.valueOf(20000L))
+										.build(),
+								PaymentOrder.builder()
+										.id(3L)
+										.productId(3L)
+										.orderId(orderId)
+										.orderName("Product 3")
+										.amount(BigDecimal.valueOf(30000L))
+										.build()));
+
+		paymentEventRepository.save(
+				PaymentEvent.builder()
+						.id(1L)
+						.buyerId(1L)
+						.orderId(orderId)
+						.paymentOrders(paymentOrders)
+						.orderName("Product 1, Product 2, Product 3")
+						.paymentStatus(PaymentStatus.READY)
+						.build());
+	}
+
+	@Override
+	public void setOrderId(String orderId) {
+		this.orderId = orderId;
 	}
 }

--- a/src/test/java/com/ordertogether/team14_be/payment/service/PaymentConfirmServiceTest.java
+++ b/src/test/java/com/ordertogether/team14_be/payment/service/PaymentConfirmServiceTest.java
@@ -1,0 +1,101 @@
+package com.ordertogether.team14_be.payment.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.ordertogether.team14_be.helper.PaymentDatabaseHelper;
+import com.ordertogether.team14_be.member.persistence.MemberRepository;
+import com.ordertogether.team14_be.payment.domain.PaymentStatus;
+import com.ordertogether.team14_be.payment.persistence.repository.PaymentEventRepository;
+import com.ordertogether.team14_be.payment.persistence.repository.PaymentOrderRepository;
+import com.ordertogether.team14_be.payment.persistence.repository.ProductRepository;
+import com.ordertogether.team14_be.payment.web.request.PaymentConfirmRequest;
+import com.ordertogether.team14_be.payment.web.response.PaymentConfirmationResponse;
+import com.ordertogether.team14_be.payment.web.toss.client.TossPaymentsClient;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles(profiles = "test")
+class PaymentConfirmServiceTest {
+
+	@MockBean PaymentConfirmService paymentConfirmService;
+
+	@Autowired PaymentDatabaseHelper paymentDatabaseHelper;
+
+	@Autowired PaymentValidationService paymentValidationService;
+	@Autowired PaymentStatusUpdateService paymentStatusUpdateService;
+	@Autowired PointManagementService pointManagementService;
+
+	@Autowired PaymentOrderRepository paymentOrderRepository;
+	@Autowired PaymentEventRepository paymentEventRepository;
+	@Autowired ProductRepository productRepository;
+	@Autowired MemberRepository memberRepository;
+
+	@Mock TossPaymentsClient tossPaymentsClient;
+
+	@BeforeEach
+	void setUp() {
+		paymentConfirmService =
+				new PaymentConfirmService(
+						tossPaymentsClient,
+						paymentValidationService,
+						paymentStatusUpdateService,
+						pointManagementService);
+
+		paymentDatabaseHelper.clean();
+
+		paymentDatabaseHelper.setOrderId("test-order-id");
+		paymentDatabaseHelper.saveTestData();
+	}
+
+	@Test
+	@DisplayName("결제 승인 성공 시, 결제 상태를 성공으로 저장하고 포인트를 증가시킨다")
+	void shouldSaveSuccessStatusWhenNormallyRequest() {
+		// given
+		int beforePoint =
+				memberRepository
+						.findById(1L)
+						.orElseThrow(() -> new NoSuchElementException("Member not found"))
+						.getPoint();
+
+		long chargeAmount = 60000L;
+		PaymentConfirmRequest request =
+				PaymentConfirmRequest.builder()
+						.orderId("test-order-id")
+						.paymentKey(UUID.randomUUID().toString())
+						.amount(chargeAmount)
+						.build();
+
+		// when
+		when(tossPaymentsClient.confirmPayment(any(PaymentConfirmRequest.class)))
+				.thenReturn(new PaymentConfirmationResponse(PaymentStatus.SUCCESS, null));
+
+		PaymentConfirmationResponse response = paymentConfirmService.confirm(request);
+
+		// then
+		int afterPoint =
+				memberRepository
+						.findById(1L)
+						.orElseThrow(() -> new NoSuchElementException("Member not found"))
+						.getPoint();
+
+		assertAll(
+				() -> assertThat(afterPoint).isEqualTo(beforePoint + chargeAmount),
+				() -> assertThat(response.paymentStatus()).isEqualTo(PaymentStatus.SUCCESS),
+				() -> assertThat(response.failure()).isNull());
+	}
+}

--- a/src/test/java/com/ordertogether/team14_be/payment/service/PaymentPreparationServiceTest.java
+++ b/src/test/java/com/ordertogether/team14_be/payment/service/PaymentPreparationServiceTest.java
@@ -54,7 +54,7 @@ class PaymentPreparationServiceTest {
 		assertThat(response.paymentOrders()).hasSize(3);
 		assertThat(response.orderId()).isNotNull();
 		assertThat(response.orderName()).isEqualTo("Product 1,Product 2,Product 3");
-		assertThat(response.paymentKey()).isNotNull();
+		assertThat(response.paymentKey()).isNull();
 		response.paymentOrders().stream()
 				.forEach(
 						paymentOrder -> {

--- a/src/test/java/com/ordertogether/team14_be/payment/service/PaymentStatusUpdateServiceTest.java
+++ b/src/test/java/com/ordertogether/team14_be/payment/service/PaymentStatusUpdateServiceTest.java
@@ -1,0 +1,72 @@
+package com.ordertogether.team14_be.payment.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ordertogether.team14_be.helper.PaymentDatabaseHelper;
+import com.ordertogether.team14_be.payment.domain.PaymentEvent;
+import com.ordertogether.team14_be.payment.domain.PaymentOrder;
+import com.ordertogether.team14_be.payment.domain.PaymentStatus;
+import com.ordertogether.team14_be.payment.persistence.repository.PaymentEventRepository;
+import com.ordertogether.team14_be.payment.service.command.PaymentStatusUpdateCommand;
+import java.math.BigDecimal;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class PaymentStatusUpdateServiceTest {
+
+	@Autowired PaymentStatusUpdateService paymentStatusUpdateService;
+
+	@Autowired PaymentDatabaseHelper paymentDatabaseHelper;
+
+	@Autowired PaymentEventRepository paymentEventRepository;
+
+	@BeforeEach
+	void setup() {
+		paymentDatabaseHelper.clean();
+
+		paymentEventRepository.save(
+				PaymentEvent.builder()
+						.id(1L)
+						.paymentOrders(
+								List.of(
+										PaymentOrder.builder()
+												.id(1L)
+												.orderId("test-order-id")
+												.orderName("test-order-name01")
+												.amount(BigDecimal.valueOf(1000))
+												.productId(1L)
+												.build(),
+										PaymentOrder.builder()
+												.id(2L)
+												.orderId("test-order-id")
+												.orderName("test-order-name02")
+												.amount(BigDecimal.valueOf(2000))
+												.productId(2L)
+												.build()))
+						.paymentStatus(PaymentStatus.READY)
+						.buyerId(1L)
+						.paymentKey("test-payment-key")
+						.orderId("test-order-id")
+						.orderName("test-order-name01, test-order-name02")
+						.build());
+	}
+
+	@ParameterizedTest(name = "PaymentEvent의 상태를 READY 에서 {0} 으로 변경할 수 있다.")
+	@EnumSource
+	void shouldUpdateStatusWithNormalRequest(PaymentStatus paymentStatus) {
+		PaymentStatusUpdateCommand command =
+				new PaymentStatusUpdateCommand("test-payment-key", "test-order-id", paymentStatus);
+		paymentStatusUpdateService.updatePaymentStatus(command);
+
+		PaymentEvent result = paymentEventRepository.findByOrderId("test-order-id").get();
+
+		assertThat(result.getPaymentStatus()).isEqualTo(paymentStatus);
+	}
+}

--- a/src/test/java/com/ordertogether/team14_be/payment/service/PointManagementServiceTest.java
+++ b/src/test/java/com/ordertogether/team14_be/payment/service/PointManagementServiceTest.java
@@ -1,0 +1,61 @@
+package com.ordertogether.team14_be.payment.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ordertogether.team14_be.helper.PaymentDatabaseHelper;
+import com.ordertogether.team14_be.member.persistence.MemberRepository;
+import com.ordertogether.team14_be.payment.persistence.repository.PaymentEventRepository;
+import java.util.NoSuchElementException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles(profiles = "test")
+class PointManagementServiceTest {
+
+	@Autowired PointManagementService pointManagementService;
+
+	@Autowired MemberRepository memberRepository;
+	@Autowired PaymentEventRepository paymentEventRepository;
+
+	@Autowired PaymentDatabaseHelper paymentDatabaseHelper;
+
+	@BeforeEach
+	void setUp() {
+		paymentDatabaseHelper.clean();
+
+		paymentDatabaseHelper.setOrderId("test-order-id");
+		paymentDatabaseHelper.saveTestData();
+	}
+
+	@Test
+	@DisplayName("구매 금액만큼 포인트가 증가한다")
+	void shouldIncreaseSuccessWhenNormallyRequest() {
+		// given
+		int beforePoint =
+				memberRepository
+						.findById(1L)
+						.orElseThrow(() -> new NoSuchElementException("Member not found"))
+						.getPoint();
+		Long chargeAmount =
+				paymentEventRepository
+						.findByOrderId("test-order-id")
+						.orElseThrow(() -> new NoSuchElementException("PaymentEvent not found"))
+						.totalAmount();
+
+		// when
+		pointManagementService.increasePoint("test-order-id");
+
+		// then
+		int afterPoint =
+				memberRepository
+						.findById(1L)
+						.orElseThrow(() -> new NoSuchElementException("Member not found"))
+						.getPoint();
+		assertThat(afterPoint).isEqualTo(beforePoint + chargeAmount);
+	}
+}

--- a/src/test/java/com/ordertogether/team14_be/payment/service/PointUpdateServiceTest.java
+++ b/src/test/java/com/ordertogether/team14_be/payment/service/PointUpdateServiceTest.java
@@ -1,0 +1,62 @@
+package com.ordertogether.team14_be.payment.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.ordertogether.team14_be.helper.PaymentDatabaseHelper;
+import com.ordertogether.team14_be.member.persistence.MemberRepository;
+import com.ordertogether.team14_be.payment.persistence.repository.PaymentEventRepository;
+import java.util.NoSuchElementException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles(profiles = "test")
+class PointUpdateServiceTest {
+
+	@Autowired PointUpdateService pointUpdateService;
+
+	@Autowired MemberRepository memberRepository;
+	@Autowired PaymentEventRepository paymentEventRepository;
+
+	@Autowired PaymentDatabaseHelper paymentDatabaseHelper;
+
+	@BeforeEach
+	void setUp() {
+		paymentDatabaseHelper.clean();
+
+		paymentDatabaseHelper.setOrderId("test-order-id");
+		paymentDatabaseHelper.saveTestData();
+	}
+
+	@Test
+	@DisplayName("구매 금액만큼 포인트가 증가한다")
+	void shouldIncreaseSuccessWhenNormallyRequest() {
+		// given
+		int beforePoint =
+				memberRepository
+						.findById(1L)
+						.orElseThrow(() -> new NoSuchElementException("Member not found"))
+						.getPoint();
+		Long chargeAmount =
+				paymentEventRepository
+						.findByOrderId("test-order-id")
+						.orElseThrow(() -> new NoSuchElementException("PaymentEvent not found"))
+						.totalAmount();
+
+		// when
+		pointUpdateService.increasePoint("test-order-id");
+
+		// then
+		int afterPoint =
+				memberRepository
+						.findById(1L)
+						.orElseThrow(() -> new NoSuchElementException("Member not found"))
+						.getPoint();
+		assertThat(afterPoint).isEqualTo(beforePoint + chargeAmount);
+	}
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -42,6 +42,18 @@ kakao:
     api:
       url: ${KAKAO_USER_API_URL}
 
+pg:
+  toss:
+    secret-key: test_gsk_docs_OaPz8L5KdmQXkzRz3y47BMw6
+    url: https://api.tosspayments.com
+
 key:
   jwt:
     secret-key: ${JWT_SECRET_KEY}
+
+jwt:
+  expire-time: 1
+
+front:
+  page:
+    signup: ${FRONT_PAGE_SIGNUP}


### PR DESCRIPTION
📌 관련 이슈
---
* #60 
* #62 
* #59 
* #36 

✨ PR 내용
---
9주차 개발사항 적용했습니다.

## 궁금한점
***
### 1. 트랜잭션 분리
```java
@Service
@Slf4j
@RequiredArgsConstructor
/** 결제 승인 서비스 */
public class PaymentConfirmService {

	private final TossPaymentsClient tossPaymentsClient;

	private final PaymentValidationService paymentValidationService;
	private final PaymentStatusUpdateService paymentStatusUpdateService;
	private final PointUpdateService pointUpdateService;

	@Transactional
	public PaymentConfirmationResponse confirm(PaymentConfirmRequest request) {
		// 1. 결제 상태 변경 (준비 -> 실행 중)
		paymentStatusUpdateService.updatePaymentStatusToExecuting(request.orderId(), request.paymentKey());
		// 2. 결제 유효성 검사
		paymentValidationService.validate(request.orderId(), BigDecimal.valueOf(request.amount()));
		// 3. 결제 승인 요청
		PaymentConfirmationResponse response = tossPaymentsClient.confirmPayment(request);
		// 4. 승인 결과에 따른 결제 상태 업데이트
		paymentStatusUpdateService.updatePaymentStatus(new PaymentStatusUpdateCommand(request.paymentKey(), request.orderId(), response.paymentStatus()));
		// 5. 포인트 충전
		pointUpdateService.increasePoint(request.orderId());
		return response;
	}

}
```
`confirm` 메소드에서 하나의 트랜잭션으로 5개의 로직이 수행될 때 “결제 상태 변경”과 같은 부가기능의 실패로 결제 승인에 성공하였음에도 DB에 올바르게 기록되지 못하는 상황을 방지하기 위해 트랜잭션을 분리할 수 있나요?

현재 결제 승인 내부 로직 전체를 한 트랜잭션으로 수행 중인데 여기서 수행되는 몇몇의 기능은 별도의 트랜잭션에서 수행되도록 구현하고 싶은데 어떤 방법이 좋을지 궁금합니다!
### 2. 카카오 로그아웃
<details>
  <summary>카카오 로그아웃 방식</summary>

  1. 서비스 토큰만 만료
  - 장점: 간편하다
  - 단점: 로그아웃하고 다시 로그인할 때 바로 로그인되버려서 계정을 못 바꾼다
  
  2. 카카오 로그아웃
  - 요청: 액세스토큰(카카오의)
  - 응답: 사용자 카카오 아이디
  - 카카오 액세스토큰을 만료시킨다
  - 서비스토큰 만료는 별도로 구현
  

  3. 카카오 계정과 함께 로그아웃
  -요청: 앱 키, 리다이렉트 url (서비스로그아웃할)
  -응답: 별도로 없음
  - 여기서 **카카오 계정과 함께 로그아웃**은 요청으로 보내는 거에 사용자 관련 내용이 없는데 어떻게 사용자를 식별에서 로그아웃을 시키는지 알기 어려웠습니다. 이에 대한 멘토님의 도움이 필요합니다,,,
  - 저의 추측: 카카오와 관련된 사용자 정보가 쿠키로써 브라우저에 저장되어 있어서 그걸 활용
  
  구현에 어려움이 있는 것은 아니나 3번 카카오 계정과 함께 로그아웃 방식에 대해서 완벽히 이해하지 못 해 멘토님께 도움을 얻고 싶어 질문드립니다!
</details>